### PR TITLE
MSVC setup for the OSACA project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# Visual Studio
+.vs
+x64/

--- a/msvc/OSACA.pyproj
+++ b/msvc/OSACA.pyproj
@@ -1,0 +1,86 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{88ef9105-2c58-41fe-ad9f-f54c96a7e8b3}</ProjectGuid>
+    <ProjectHome>..\</ProjectHome>
+    <StartupFile>tests\test_parser_x86att.py</StartupFile>
+    <SearchPath />
+    <WorkingDirectory>.</WorkingDirectory>
+    <OutputPath>.</OutputPath>
+    <ProjectTypeGuids>{888888a0-9f3d-457c-b088-3a5042f75d52}</ProjectTypeGuids>
+    <LaunchProvider>Standard Python launcher</LaunchProvider>
+    <InterpreterId />
+    <TestFramework>Pytest</TestFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'" />
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'" />
+  <PropertyGroup>
+    <VisualStudioVersion Condition=" '$(VisualStudioVersion)' == '' ">10.0</VisualStudioVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Content Include="docs\img\osaca-logo.png" />
+    <Content Include="docs\img\osaca-workflow.png" />
+    <Content Include="tox.ini" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="docs\conf.py" />
+    <Compile Include="docs\version_from_src.py" />
+    <Compile Include="osaca\data\create_db_entry.py" />
+    <Compile Include="osaca\data\generate_mov_entries.py" />
+    <Compile Include="osaca\data\model_importer.py" />
+    <Compile Include="osaca\data\pmevo_importer.py" />
+    <Compile Include="osaca\data\_build_cache.py" />
+    <Compile Include="osaca\db_interface.py" />
+    <Compile Include="osaca\frontend.py" />
+    <Compile Include="osaca\osaca.py" />
+    <Compile Include="osaca\parser\base_parser.py" />
+    <Compile Include="osaca\parser\condition.py" />
+    <Compile Include="osaca\parser\directive.py" />
+    <Compile Include="osaca\parser\flag.py" />
+    <Compile Include="osaca\parser\identifier.py" />
+    <Compile Include="osaca\parser\immediate.py" />
+    <Compile Include="osaca\parser\instruction_form.py" />
+    <Compile Include="osaca\parser\label.py" />
+    <Compile Include="osaca\parser\memory.py" />
+    <Compile Include="osaca\parser\operand.py" />
+    <Compile Include="osaca\parser\parser_AArch64.py" />
+    <Compile Include="osaca\parser\parser_x86att.py" />
+    <Compile Include="osaca\parser\prefetch.py" />
+    <Compile Include="osaca\parser\register.py" />
+    <Compile Include="osaca\parser\__init__.py" />
+    <Compile Include="osaca\semantics\arch_semantics.py" />
+    <Compile Include="osaca\semantics\hw_model.py" />
+    <Compile Include="osaca\semantics\isa_semantics.py" />
+    <Compile Include="osaca\semantics\kernel_dg.py" />
+    <Compile Include="osaca\semantics\marker_utils.py" />
+    <Compile Include="osaca\semantics\__init__.py" />
+    <Compile Include="osaca\utils.py" />
+    <Compile Include="osaca\__init__.py" />
+    <Compile Include="osaca\__main__.py" />
+    <Compile Include="setup.py" />
+    <Compile Include="tests\all_tests.py" />
+    <Compile Include="tests\test_base_parser.py" />
+    <Compile Include="tests\test_cli.py" />
+    <Compile Include="tests\test_db_interface.py" />
+    <Compile Include="tests\test_frontend.py" />
+    <Compile Include="tests\test_marker_utils.py" />
+    <Compile Include="tests\test_parser_AArch64.py" />
+    <Compile Include="tests\test_parser_x86att.py" />
+    <Compile Include="tests\test_semantics.py" />
+    <Compile Include="tests\__init__.py" />
+    <Compile Include="validation\build_and_run.py" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="docs" />
+    <Folder Include="docs\img" />
+    <Folder Include="osaca" />
+    <Folder Include="osaca\data" />
+    <Folder Include="osaca\parser" />
+    <Folder Include="osaca\semantics" />
+    <Folder Include="tests" />
+    <Folder Include="validation" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />
+</Project>

--- a/msvc/OSACA.sln
+++ b/msvc/OSACA.sln
@@ -1,0 +1,45 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.35327.3
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{888888A0-9F3D-457C-B088-3A5042F75D52}") = "OSACA", "OSACA.pyproj", "{88EF9105-2C58-41FE-AD9F-F54C96A7E8B3}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "validation", "validation.vcxproj", "{98B24C7F-9970-4640-8496-2EC1E07BDF2A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{88EF9105-2C58-41FE-AD9F-F54C96A7E8B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{88EF9105-2C58-41FE-AD9F-F54C96A7E8B3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{88EF9105-2C58-41FE-AD9F-F54C96A7E8B3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{88EF9105-2C58-41FE-AD9F-F54C96A7E8B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{88EF9105-2C58-41FE-AD9F-F54C96A7E8B3}.Release|x64.ActiveCfg = Release|Any CPU
+		{88EF9105-2C58-41FE-AD9F-F54C96A7E8B3}.Release|x86.ActiveCfg = Release|Any CPU
+		{98B24C7F-9970-4640-8496-2EC1E07BDF2A}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{98B24C7F-9970-4640-8496-2EC1E07BDF2A}.Debug|Any CPU.Build.0 = Debug|x64
+		{98B24C7F-9970-4640-8496-2EC1E07BDF2A}.Debug|x64.ActiveCfg = Debug|x64
+		{98B24C7F-9970-4640-8496-2EC1E07BDF2A}.Debug|x64.Build.0 = Debug|x64
+		{98B24C7F-9970-4640-8496-2EC1E07BDF2A}.Debug|x86.ActiveCfg = Debug|Win32
+		{98B24C7F-9970-4640-8496-2EC1E07BDF2A}.Debug|x86.Build.0 = Debug|Win32
+		{98B24C7F-9970-4640-8496-2EC1E07BDF2A}.Release|Any CPU.ActiveCfg = Release|x64
+		{98B24C7F-9970-4640-8496-2EC1E07BDF2A}.Release|Any CPU.Build.0 = Release|x64
+		{98B24C7F-9970-4640-8496-2EC1E07BDF2A}.Release|x64.ActiveCfg = Release|x64
+		{98B24C7F-9970-4640-8496-2EC1E07BDF2A}.Release|x64.Build.0 = Release|x64
+		{98B24C7F-9970-4640-8496-2EC1E07BDF2A}.Release|x86.ActiveCfg = Release|Win32
+		{98B24C7F-9970-4640-8496-2EC1E07BDF2A}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {213DDB09-EC54-434E-B900-2DD90E070750}
+	EndGlobalSection
+EndGlobal

--- a/msvc/validation.vcxproj
+++ b/msvc/validation.vcxproj
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{98b24c7f-9970-4640-8496-2ec1e07bdf2a}</ProjectGuid>
+    <RootNamespace>validation</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AssemblerOutput>AssemblyCode</AssemblerOutput>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <Lib>
+      <AdditionalOptions>/IGNORE:4006 %(AdditionalOptions)</AdditionalOptions>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AssemblerOutput>AssemblyCode</AssemblerOutput>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <Lib>
+      <AdditionalOptions>/IGNORE:4006 %(AdditionalOptions)</AdditionalOptions>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\validation\kernels\2d-5pt.c" />
+    <ClCompile Include="..\validation\kernels\3d-27pt.c" />
+    <ClCompile Include="..\validation\kernels\3d-7pt.c" />
+    <ClCompile Include="..\validation\kernels\3d-r3-11pt.c" />
+    <ClCompile Include="..\validation\kernels\add.c" />
+    <ClCompile Include="..\validation\kernels\copy.c" />
+    <ClCompile Include="..\validation\kernels\dummy.c" />
+    <ClCompile Include="..\validation\kernels\gs-2d-5pt.c" />
+    <ClCompile Include="..\validation\kernels\pi.c" />
+    <ClCompile Include="..\validation\kernels\store.c" />
+    <ClCompile Include="..\validation\kernels\striad.c" />
+    <ClCompile Include="..\validation\kernels\sumreduction.c" />
+    <ClCompile Include="..\validation\kernels\triad.c" />
+    <ClCompile Include="..\validation\kernels\update.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/msvc/validation.vcxproj.filters
+++ b/msvc/validation.vcxproj.filters
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\validation\kernels\2d-5pt.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\validation\kernels\3d-7pt.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\validation\kernels\3d-27pt.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\validation\kernels\3d-r3-11pt.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\validation\kernels\add.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\validation\kernels\copy.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\validation\kernels\dummy.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\validation\kernels\gs-2d-5pt.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\validation\kernels\pi.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\validation\kernels\store.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\validation\kernels\striad.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\validation\kernels\sumreduction.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\validation\kernels\triad.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\validation\kernels\update.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/msvc/validation.vcxproj.user
+++ b/msvc/validation.vcxproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>


### PR DESCRIPTION
This sets up:
1. A Python project containing the code and test for the project.
2. A C project containing the C code used to validate the parser and friends.  That project is really only used for producing `.asm` files.  Its output is a static library, but the warnings have to be ignored because each file defines the same symbols.