### PR TITLE
Support for detecting the IACA markers in the parsed code

### DIFF
--- a/msvc/OSACA.pyproj
+++ b/msvc/OSACA.pyproj
@@ -5,7 +5,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{88ef9105-2c58-41fe-ad9f-f54c96a7e8b3}</ProjectGuid>
     <ProjectHome>..\</ProjectHome>
-    <StartupFile>tests\test_parser_x86intel.py</StartupFile>
+    <StartupFile>tests\test_marker_utils.py</StartupFile>
     <SearchPath />
     <WorkingDirectory>.</WorkingDirectory>
     <OutputPath>.</OutputPath>

--- a/osaca/osaca.py
+++ b/osaca/osaca.py
@@ -373,7 +373,7 @@ def inspect(args, output_file=sys.stdout):
         kernel = [line for line in parsed_code if line.line_number in line_range]
         print_length_warning = False
     else:
-        kernel = reduce_to_section(parsed_code, isa, syntax)
+        kernel = reduce_to_section(parsed_code, parser)
         # Print warning if kernel has no markers and is larger than threshold (100)
         print_length_warning = (
             True if len(kernel) == len(parsed_code) and len(kernel) > 100 else False

--- a/osaca/parser/base_parser.py
+++ b/osaca/parser/base_parser.py
@@ -25,6 +25,26 @@ class BaseParser(object):
             self.construct_parser()
             self._parser_constructed = True
 
+    def isa(self):
+        # Done in derived classes
+        raise NotImplementedError
+
+    # The marker functions return lists of `InstructionForm` that are used to find the IACA markers
+    # in the parsed code.  In addition to just a list, the marker may have a structure like
+    # [I1, [I2, I3], I4, ...] where the nested list indicates that at least one of I2 and I3 must
+    # match the second instruction in the fragment of parsed code.
+    # If an instruction form is a `DirectiveOperand`, the match may happen over several directive
+    # operands in the parsed code, provided that the directives have the same name and the
+    # parameters are in sequence with respect to the pattern.  This provides an easy way to describe
+    # a sequence of bytes irrespective of the way it was grouped in the assemble source.
+    def start_marker(self):
+        # Done in derived classes
+        raise NotImplementedError
+
+    def end_marker(self):
+        # Done in derived classes
+        raise NotImplementedError
+
     @staticmethod
     def detect_ISA(file_content):
         """

--- a/osaca/parser/parser_AArch64.py
+++ b/osaca/parser/parser_AArch64.py
@@ -34,18 +34,22 @@ class ParserAArch64(BaseParser):
         return [
             InstructionForm(
                 mnemonic="mov",
-                operands=[RegisterOperand(name="x1"), ImmediateOperand(value=111)]
+                operands=[RegisterOperand(name="1", prefix="x"), ImmediateOperand(value=111)]
             ),
-            DirectiveOperand(name="byte", parameters=["213", "3", "32", "31"])
+            InstructionForm(
+                directive_id=DirectiveOperand(name="byte", parameters=["213", "3", "32", "31"])
+            )
         ]
 
     def end_marker(self):
         return [
             InstructionForm(
                 mnemonic="mov",
-                operands=[RegisterOperand(name="x1"), ImmediateOperand(value=222)]
+                operands=[RegisterOperand(name="1", prefix="x"), ImmediateOperand(value=222)]
             ),
-            DirectiveOperand(name="byte", parameters=["213", "3", "32", "31"])
+            InstructionForm(
+                directive_id=DirectiveOperand(name="byte", parameters=["213", "3", "32", "31"])
+            )
         ]
 
     def construct_parser(self):

--- a/osaca/parser/parser_AArch64.py
+++ b/osaca/parser/parser_AArch64.py
@@ -26,7 +26,27 @@ class ParserAArch64(BaseParser):
 
     def __init__(self):
         super().__init__()
-        self.isa = "aarch64"
+
+    def isa(self):
+        return "aarch64"
+
+    def start_marker(self):
+        return [
+            InstructionForm(
+                mnemonic="mov",
+                operands=[RegisterOperand(name="x1"), ImmediateOperand(value=111)]
+            ),
+            DirectiveOperand(name="byte", parameters=["213", "3", "32", "31"])
+        ]
+
+    def end_marker(self):
+        return [
+            InstructionForm(
+                mnemonic="mov",
+                operands=[RegisterOperand(name="x1"), ImmediateOperand(value=222)]
+            ),
+            DirectiveOperand(name="byte", parameters=["213", "3", "32", "31"])
+        ]
 
     def construct_parser(self):
         """Create parser for ARM AArch64 ISA."""

--- a/osaca/parser/parser_x86att.py
+++ b/osaca/parser/parser_x86att.py
@@ -32,7 +32,7 @@ class ParserX86ATT(BaseParser):
 
     def start_marker(self):
         return [
-            [
+            {
                 InstructionForm(
                     mnemonic="mov",
                     operands=[ImmediateOperand(value=111), RegisterOperand(name="ebx")]
@@ -41,8 +41,10 @@ class ParserX86ATT(BaseParser):
                      mnemonic="movl",
                      operands=[ImmediateOperand(value=111), RegisterOperand(name="ebx")]
                  )
-            ],
-            DirectiveOperand(name="byte", parameters=["100", "103", "144"])
+            },
+            InstructionForm(
+                directive_id=DirectiveOperand(name="byte", parameters=["100", "103", "144"])
+            )
         ]
 
     def end_marker(self):
@@ -57,7 +59,9 @@ class ParserX86ATT(BaseParser):
                      operands=[ImmediateOperand(value=222), RegisterOperand(name="ebx")]
                  )
             ],
-            DirectiveOperand(name="byte", parameters=["100", "103", "144"])
+            InstructionForm(
+                directive_id=DirectiveOperand(name="byte", parameters=["100", "103", "144"])
+            )
         ]
 
     def construct_parser(self):

--- a/osaca/parser/parser_x86att.py
+++ b/osaca/parser/parser_x86att.py
@@ -26,7 +26,39 @@ class ParserX86ATT(BaseParser):
 
     def __init__(self):
         super().__init__()
-        self.isa = "x86"
+
+    def isa(self):
+        return "x86"
+
+    def start_marker(self):
+        return [
+            [
+                InstructionForm(
+                    mnemonic="mov",
+                    operands=[ImmediateOperand(value=111), RegisterOperand(name="ebx")]
+                 ),
+                 InstructionForm(
+                     mnemonic="movl",
+                     operands=[ImmediateOperand(value=111), RegisterOperand(name="ebx")]
+                 )
+            ],
+            DirectiveOperand(name="byte", parameters=["100", "103", "144"])
+        ]
+
+    def end_marker(self):
+        return [
+            [
+                InstructionForm(
+                    mnemonic="mov",
+                    operands=[ImmediateOperand(value=222), RegisterOperand(name="ebx")]
+                 ),
+                 InstructionForm(
+                     mnemonic="movl",
+                     operands=[ImmediateOperand(value=222), RegisterOperand(name="ebx")]
+                 )
+            ],
+            DirectiveOperand(name="byte", parameters=["100", "103", "144"])
+        ]
 
     def construct_parser(self):
         """Create parser for x86 AT&T ISA."""

--- a/osaca/parser/parser_x86att.py
+++ b/osaca/parser/parser_x86att.py
@@ -32,7 +32,7 @@ class ParserX86ATT(BaseParser):
 
     def start_marker(self):
         return [
-            {
+            [
                 InstructionForm(
                     mnemonic="mov",
                     operands=[ImmediateOperand(value=111), RegisterOperand(name="ebx")]
@@ -41,7 +41,7 @@ class ParserX86ATT(BaseParser):
                      mnemonic="movl",
                      operands=[ImmediateOperand(value=111), RegisterOperand(name="ebx")]
                  )
-            },
+            ],
             InstructionForm(
                 directive_id=DirectiveOperand(name="byte", parameters=["100", "103", "144"])
             )

--- a/osaca/parser/parser_x86intel.py
+++ b/osaca/parser/parser_x86intel.py
@@ -12,8 +12,9 @@ from osaca.parser.memory import MemoryOperand
 from osaca.parser.register import RegisterOperand
 
 # References:
-#   ASM386 Assembly Language Reference, document number 469165-003, https://mirror.math.princeton.edu/pub/oldlinux/Linux.old/Ref-docs/asm-ref.pdf
+#   ASM386 Assembly Language Reference, document number 469165-003, https://mirror.math.princeton.edu/pub/oldlinux/Linux.old/Ref-docs/asm-ref.pdf.
 #   Microsoft Macro Assembler BNF Grammar, https://learn.microsoft.com/en-us/cpp/assembler/masm/masm-bnf-grammar?view=msvc-170.
+#   Intel® Architecture Code Analyzer User's Guide, https://www.intel.com/content/dam/develop/external/us/en/documents/intel-architecture-code-analyzer-3-0-users-guide-157552.pdf.
 class ParserX86Intel(BaseParser):
     _instance = None
 
@@ -25,7 +26,33 @@ class ParserX86Intel(BaseParser):
 
     def __init__(self):
         super().__init__()
-        self.isa = "x86"
+
+    def isa(self):
+        return "x86"
+
+    # The IACA manual says: "For For Microsoft* Visual C++ compiler, 64-bit version, use
+    # IACA_VC64_START and IACA_VC64_END, instead" (of IACA_START and IACA_END).
+    def start_marker(self):
+        return [
+            InstructionForm(
+                mnemonic="mov",
+                operands=[RegisterOperand(name="al"), ImmediateOperand(value=111)]
+            ),
+            InstructionForm(
+                mnemonic="mov",
+                operands=[MemoryOperand(
+                    RegisterOperand(name="gs")), RegisterOperand(name="al")]
+            ),
+        ]
+
+    def end_marker(self):
+        return [
+            InstructionForm(
+                mnemonic="mov",
+                operands=[RegisterOperand(name="x1"), ImmediateOperand(value=222)]
+            ),
+            DirectiveOperand(name="byte", parameters=["213", "3", "32", "31"])
+        ]
 
     def construct_parser(self):
         """Create parser for x86 Intel ISA."""

--- a/osaca/parser/parser_x86intel.py
+++ b/osaca/parser/parser_x86intel.py
@@ -14,7 +14,7 @@ from osaca.parser.register import RegisterOperand
 # References:
 #   ASM386 Assembly Language Reference, document number 469165-003, https://mirror.math.princeton.edu/pub/oldlinux/Linux.old/Ref-docs/asm-ref.pdf.
 #   Microsoft Macro Assembler BNF Grammar, https://learn.microsoft.com/en-us/cpp/assembler/masm/masm-bnf-grammar?view=msvc-170.
-#   Intel® Architecture Code Analyzer User's Guide, https://www.intel.com/content/dam/develop/external/us/en/documents/intel-architecture-code-analyzer-3-0-users-guide-157552.pdf.
+#   Intel Architecture Code Analyzer User's Guide, https://www.intel.com/content/dam/develop/external/us/en/documents/intel-architecture-code-analyzer-3-0-users-guide-157552.pdf.
 class ParserX86Intel(BaseParser):
     _instance = None
 

--- a/osaca/parser/parser_x86intel.py
+++ b/osaca/parser/parser_x86intel.py
@@ -36,12 +36,17 @@ class ParserX86Intel(BaseParser):
         return [
             InstructionForm(
                 mnemonic="mov",
-                operands=[RegisterOperand(name="al"), ImmediateOperand(value=111)]
+                operands=[RegisterOperand(name="AL"), ImmediateOperand(value=111)]
             ),
             InstructionForm(
                 mnemonic="mov",
-                operands=[MemoryOperand(
-                    RegisterOperand(name="gs")), RegisterOperand(name="al")]
+                operands=[
+                    MemoryOperand(
+                        base=RegisterOperand(name="GS"),
+                        offset=ImmediateOperand(value=111)
+                    ),
+                    RegisterOperand(name="AL")
+                ]
             ),
         ]
 
@@ -49,9 +54,18 @@ class ParserX86Intel(BaseParser):
         return [
             InstructionForm(
                 mnemonic="mov",
-                operands=[RegisterOperand(name="x1"), ImmediateOperand(value=222)]
+                operands=[RegisterOperand(name="AL"), ImmediateOperand(value=222)]
             ),
-            DirectiveOperand(name="byte", parameters=["213", "3", "32", "31"])
+            InstructionForm(
+                mnemonic="mov",
+                operands=[
+                    MemoryOperand(
+                        base=RegisterOperand(name="GS"),
+                        offset=ImmediateOperand(value=222)
+                    ),
+                    RegisterOperand(name="AL")
+                ]
+            ),
         ]
 
     def construct_parser(self):

--- a/osaca/semantics/marker_utils.py
+++ b/osaca/semantics/marker_utils.py
@@ -247,24 +247,6 @@ def match_parameter(line_parameter, marker_line_parameter):
     return line_parameter.lower() == marker_line_parameter.lower()
 
 
-def match_bytes(lines, index, byte_list):
-    """Match bytes directives of markers"""
-    # either all bytes are in one line or in separate ones
-    extracted_bytes = []
-    line_count = 0
-    while (
-        index < len(lines)
-        and lines[index].directive is not None
-        and lines[index].directive.name == "byte"
-    ):
-        line_count += 1
-        extracted_bytes += [int(x, 0) for x in lines[index].directive.parameters]
-        index += 1
-    if extracted_bytes[0 : len(byte_list)] == byte_list:
-        return True, line_count
-    return False, -1
-
-
 def find_jump_labels(lines):
     """
     Find and return all labels which are followed by instructions until the next label

--- a/osaca/semantics/marker_utils.py
+++ b/osaca/semantics/marker_utils.py
@@ -96,13 +96,13 @@ def find_marked_section(lines, parser, comments=None):
                     index_start = i + 1
                 elif comments["end"] == line.comment:
                     index_end = i
-            elif index_start == -1:
+            if index_start == -1:
                 start_marker = parser.start_marker()
                 matches, length = match_lines(parser, lines, i, start_marker)
                 if matches:
                     # return first line after the marker
                     index_start = i + length
-            else:
+            if index_end == -1:
                 end_marker = parser.end_marker()
                 matches, length = match_lines(parser, lines, i, end_marker)
                 if matches:

--- a/osaca/semantics/marker_utils.py
+++ b/osaca/semantics/marker_utils.py
@@ -130,7 +130,7 @@ def match_lines(parser, lines, marker):
     """
     marker_iter = iter(marker)
     marker_line = next(marker_iter)
-    for length, line in enumerate(lines):
+    for matched_lines, line in enumerate(lines):
         if isinstance(marker_line, list):
             # No support for partial matching in lists.
             for marker_alternative in marker_line:
@@ -153,7 +153,7 @@ def match_lines(parser, lines, marker):
                 marker_line = next(marker_iter, None)
         # If we have reached the last marker line, the parsed code matches the marker.
         if not marker_line:
-            return length + 1
+            return matched_lines + 1
 
 def match_line(parser, line, marker_line):
     """

--- a/osaca/semantics/marker_utils.py
+++ b/osaca/semantics/marker_utils.py
@@ -8,6 +8,7 @@ from osaca.parser.instruction_form import InstructionForm
 from osaca.parser.directive import DirectiveOperand
 from osaca.parser.identifier import IdentifierOperand
 from osaca.parser.immediate import ImmediateOperand
+from osaca.parser.memory import MemoryOperand
 from osaca.parser.register import RegisterOperand
 
 COMMENT_MARKER = {"start": "OSACA-BEGIN", "end": "OSACA-END"}
@@ -203,6 +204,13 @@ def match_operand(line_operand, marker_line_operand):
         and isinstance(marker_line_operand, RegisterOperand)
         and line_operand.name.lower() == marker_line_operand.name.lower()
     ):
+        return True
+    if (
+        isinstance(line_operand, MemoryOperand)
+        and isinstance(marker_line_operand, MemoryOperand)
+        and match_operand(line_operand.base, marker_line_operand.base)
+        and match_operand(line_operand.offset, line_operand.offset)
+        ):
         return True
     return False
 

--- a/osaca/semantics/marker_utils.py
+++ b/osaca/semantics/marker_utils.py
@@ -105,8 +105,7 @@ def find_marked_section(lines, parser, comments=None):
                     index_start = i + length
             if index_end == -1:
                 end_marker = parser.end_marker()
-                length = match_lines(parser, lines[i:], end_marker)
-                if length > 0:
+                if match_lines(parser, lines[i:], end_marker):
                     index_end = i
         except TypeError as e:
             print(i, e, line)

--- a/osaca/semantics/marker_utils.py
+++ b/osaca/semantics/marker_utils.py
@@ -99,10 +99,10 @@ def find_marked_section(lines, parser, comments=None):
                     index_end = i
             if index_start == -1:
                 start_marker = parser.start_marker()
-                length = match_lines(parser, lines[i:], start_marker)
-                if length > 0:
-                    # return first line after the marker
-                    index_start = i + length
+                matching_lines = match_lines(parser, lines[i:], start_marker)
+                if matching_lines > 0:
+                    # Return the first line after the marker.
+                    index_start = i + matching_lines
             if index_end == -1:
                 end_marker = parser.end_marker()
                 if match_lines(parser, lines[i:], end_marker):

--- a/tests/test_files/triad_x86_intel_iaca.asm
+++ b/tests/test_files/triad_x86_intel_iaca.asm
@@ -83,7 +83,7 @@ repeat$ = 320
 cur_elements$ = 328
 kernel	PROC						; COMDAT
 ; File C:\Users\phl\Projects\GitHub\OSACA\validation\kernels\triad.c
-; Line 18
+; Line 22
 $LN9:
 	movsd	QWORD PTR [rsp+32], xmm3
 	mov	QWORD PTR [rsp+24], r8
@@ -96,7 +96,7 @@ $LN9:
 	lea	rcx, OFFSET FLAT:__621B1B6F_triad@c
 	call	__CheckForDebuggerJustMyCode
 	npad	1
-; Line 19
+; Line 23
 	mov	DWORD PTR r$1[rbp], 0
 	jmp	SHORT $LN4@kernel
 $LN2@kernel:
@@ -107,7 +107,7 @@ $LN4@kernel:
 	mov	eax, DWORD PTR repeat$[rbp]
 	cmp	DWORD PTR r$1[rbp], eax
 	jge	$LN3@kernel
-; Line 20
+; Line 24
 	mov	DWORD PTR i$2[rbp], 0
 	jmp	SHORT $LN7@kernel
 $LN5@kernel:
@@ -118,10 +118,10 @@ $LN7@kernel:
 	mov	eax, DWORD PTR cur_elements$[rbp]
 	cmp	DWORD PTR i$2[rbp], eax
 	jge	SHORT $LN6@kernel
-; Line 21
+; Line 26
 	mov	al, 111					; 0000006fH
 	mov	BYTE PTR gs:111, al
-; Line 22
+; Line 28
 	movsxd	rax, DWORD PTR i$2[rbp]
 	movsxd	rcx, DWORD PTR i$2[rbp]
 	mov	rdx, QWORD PTR c$[rbp]
@@ -134,20 +134,20 @@ $LN7@kernel:
 	movsxd	rax, DWORD PTR i$2[rbp]
 	mov	rcx, QWORD PTR a$[rbp]
 	movsd	QWORD PTR [rcx+rax*8], xmm0
-; Line 23
+; Line 30
 	mov	al, 222					; 000000deH
 	mov	BYTE PTR gs:222, al
-; Line 24
+; Line 32
 	jmp	SHORT $LN5@kernel
 $LN6@kernel:
-; Line 25
+; Line 33
 	mov	rcx, QWORD PTR a$[rbp]
 	call	dummy
 	npad	1
-; Line 26
+; Line 34
 	jmp	$LN2@kernel
 $LN3@kernel:
-; Line 27
+; Line 35
 	lea	rsp, QWORD PTR [rbp+264]
 	pop	rdi
 	pop	rbp

--- a/tests/test_marker_utils.py
+++ b/tests/test_marker_utils.py
@@ -180,7 +180,7 @@ class TestMarkerUtils(unittest.TestCase):
                             bytes_end=bytes_var_2,
                         ):
                             sample_parsed = self.parser_x86.parse_file(sample_code)
-                            sample_kernel = reduce_to_section(sample_parsed, "x86", "ATT")
+                            sample_kernel = reduce_to_section(sample_parsed, ParserX86ATT())
                             self.assertEqual(len(sample_kernel), kernel_length)
                             kernel_start = len(
                                 list(
@@ -222,7 +222,7 @@ class TestMarkerUtils(unittest.TestCase):
         for test_name, pro, kernel, epi in samples:
             code = pro + kernel + epi
             parsed = self.parser_AArch.parse_file(code)
-            test_kernel = reduce_to_section(parsed, "AArch64", None)
+            test_kernel = reduce_to_section(parsed, ParserAArch64())
             if kernel:
                 kernel_length = len(kernel.strip().split("\n"))
             else:
@@ -230,7 +230,7 @@ class TestMarkerUtils(unittest.TestCase):
             self.assertEqual(
                 len(test_kernel),
                 kernel_length,
-                msg="Invalid exctracted kernel length on {!r} sample".format(test_name),
+                msg="Invalid extracted kernel length on {!r} sample".format(test_name),
             )
             if pro:
                 kernel_start = len((pro).strip().split("\n"))
@@ -240,7 +240,7 @@ class TestMarkerUtils(unittest.TestCase):
             self.assertEqual(
                 test_kernel,
                 parsed_kernel,
-                msg="Invalid exctracted kernel on {!r}".format(test_name),
+                msg="Invalid extracted kernel on {!r}".format(test_name),
             )
 
     def test_marker_special_cases_x86(self):
@@ -270,7 +270,7 @@ class TestMarkerUtils(unittest.TestCase):
         for test_name, pro, kernel, epi in samples:
             code = pro + kernel + epi
             parsed = self.parser_x86.parse_file(code)
-            test_kernel = reduce_to_section(parsed, "x86", "ATT")
+            test_kernel = reduce_to_section(parsed, ParserX86ATT())
             if kernel:
                 kernel_length = len(kernel.strip().split("\n"))
             else:
@@ -278,7 +278,7 @@ class TestMarkerUtils(unittest.TestCase):
             self.assertEqual(
                 len(test_kernel),
                 kernel_length,
-                msg="Invalid exctracted kernel length on {!r} sample".format(test_name),
+                msg="Invalid extracted kernel length on {!r} sample".format(test_name),
             )
             if pro:
                 kernel_start = len((pro).strip().split("\n"))
@@ -289,7 +289,7 @@ class TestMarkerUtils(unittest.TestCase):
             self.assertEqual(
                 test_kernel,
                 parsed_kernel,
-                msg="Invalid exctracted kernel on {!r}".format(test_name),
+                msg="Invalid extracted kernel on {!r}".format(test_name),
             )
 
     def test_find_jump_labels(self):

--- a/tests/test_marker_utils.py
+++ b/tests/test_marker_utils.py
@@ -32,13 +32,13 @@ class TestMarkerUtils(unittest.TestCase):
     #################
 
     def test_marker_detection_AArch64(self):
-        kernel = reduce_to_section(self.parsed_AArch, "AArch64", None)
+        kernel = reduce_to_section(self.parsed_AArch, ParserAArch64())
         self.assertEqual(len(kernel), 138)
         self.assertEqual(kernel[0].line_number, 307)
         self.assertEqual(kernel[-1].line_number, 444)
 
     def test_marker_detection_x86(self):
-        kernel = reduce_to_section(self.parsed_x86, "x86", "ATT")
+        kernel = reduce_to_section(self.parsed_x86, ParserX86ATT())
         self.assertEqual(len(kernel), 9)
         self.assertEqual(kernel[0].line_number, 146)
         self.assertEqual(kernel[-1].line_number, 154)

--- a/tests/test_marker_utils.py
+++ b/tests/test_marker_utils.py
@@ -12,20 +12,24 @@ from osaca.semantics import (
     find_jump_labels,
     find_basic_loop_bodies,
 )
-from osaca.parser import ParserAArch64, ParserX86ATT
+from osaca.parser import ParserAArch64, ParserX86ATT, ParserX86Intel
 
 
 class TestMarkerUtils(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         self.parser_AArch = ParserAArch64()
-        self.parser_x86 = ParserX86ATT()
+        self.parser_x86_att = ParserX86ATT()
+        self.parser_x86_intel = ParserX86Intel()
         with open(self._find_file("triad_arm_iaca.s")) as f:
             triad_code_arm = f.read()
         with open(self._find_file("triad_x86_iaca.s")) as f:
-            triad_code_x86 = f.read()
+            triad_code_x86_att = f.read()
+        with open(self._find_file("triad_x86_intel_iaca.asm")) as f:
+            triad_code_x86_intel = f.read()
         self.parsed_AArch = self.parser_AArch.parse_file(triad_code_arm)
-        self.parsed_x86 = self.parser_x86.parse_file(triad_code_x86)
+        self.parsed_x86_att = self.parser_x86_att.parse_file(triad_code_x86_att)
+        self.parsed_x86_intel = self.parser_x86_intel.parse_file(triad_code_x86_intel)
 
     #################
     # Test
@@ -37,11 +41,17 @@ class TestMarkerUtils(unittest.TestCase):
         self.assertEqual(kernel[0].line_number, 307)
         self.assertEqual(kernel[-1].line_number, 444)
 
-    def test_marker_detection_x86(self):
-        kernel = reduce_to_section(self.parsed_x86, ParserX86ATT())
+    def test_marker_detection_x86_att(self):
+        kernel = reduce_to_section(self.parsed_x86_att, ParserX86ATT())
         self.assertEqual(len(kernel), 9)
         self.assertEqual(kernel[0].line_number, 146)
         self.assertEqual(kernel[-1].line_number, 154)
+
+    def test_marker_detection_x86_intel(self):
+        kernel = reduce_to_section(self.parsed_x86_intel, ParserX86Intel())
+        self.assertEqual(len(kernel), 14)
+        self.assertEqual(kernel[0].line_number, 124)
+        self.assertEqual(kernel[-1].line_number, 137)
 
     def test_marker_matching_AArch64(self):
         # preparation
@@ -179,7 +189,7 @@ class TestMarkerUtils(unittest.TestCase):
                             mov_end=mov_end_var,
                             bytes_end=bytes_var_2,
                         ):
-                            sample_parsed = self.parser_x86.parse_file(sample_code)
+                            sample_parsed = self.parser_x86_att.parse_file(sample_code)
                             sample_kernel = reduce_to_section(sample_parsed, ParserX86ATT())
                             self.assertEqual(len(sample_kernel), kernel_length)
                             kernel_start = len(
@@ -190,7 +200,7 @@ class TestMarkerUtils(unittest.TestCase):
                                     )
                                 )
                             )
-                            parsed_kernel = self.parser_x86.parse_file(
+                            parsed_kernel = self.parser_x86_att.parse_file(
                                 kernel, start_line=kernel_start
                             )
                             self.assertEqual(sample_kernel, parsed_kernel)
@@ -269,7 +279,7 @@ class TestMarkerUtils(unittest.TestCase):
 
         for test_name, pro, kernel, epi in samples:
             code = pro + kernel + epi
-            parsed = self.parser_x86.parse_file(code)
+            parsed = self.parser_x86_att.parse_file(code)
             test_kernel = reduce_to_section(parsed, ParserX86ATT())
             if kernel:
                 kernel_length = len(kernel.strip().split("\n"))
@@ -284,7 +294,7 @@ class TestMarkerUtils(unittest.TestCase):
                 kernel_start = len((pro).strip().split("\n"))
             else:
                 kernel_start = 0
-            parsed_kernel = self.parser_x86.parse_file(kernel, start_line=kernel_start)
+            parsed_kernel = self.parser_x86_att.parse_file(kernel, start_line=kernel_start)
 
             self.assertEqual(
                 test_kernel,
@@ -294,7 +304,7 @@ class TestMarkerUtils(unittest.TestCase):
 
     def test_find_jump_labels(self):
         self.assertEqual(
-            find_jump_labels(self.parsed_x86),
+            find_jump_labels(self.parsed_x86_att),
             OrderedDict(
                 [
                     (".LFB24", 10),
@@ -358,7 +368,7 @@ class TestMarkerUtils(unittest.TestCase):
         self.assertEqual(
             [
                 (k, v[0].line_number, v[-1].line_number)
-                for k, v in find_basic_blocks(self.parsed_x86).items()
+                for k, v in find_basic_blocks(self.parsed_x86_att).items()
             ],
             [
                 (".LFB24", 11, 56),
@@ -422,7 +432,7 @@ class TestMarkerUtils(unittest.TestCase):
         self.assertEqual(
             [
                 (k, v[0].line_number, v[-1].line_number)
-                for k, v in find_basic_loop_bodies(self.parsed_x86).items()
+                for k, v in find_basic_loop_bodies(self.parsed_x86_att).items()
             ],
             [(".L4", 66, 74), (".L10", 146, 154), (".L28", 290, 300)],
         )

--- a/tests/test_marker_utils.py
+++ b/tests/test_marker_utils.py
@@ -108,7 +108,7 @@ class TestMarkerUtils(unittest.TestCase):
                             bytes_end=bytes_var_2,
                         ):
                             sample_parsed = self.parser_AArch.parse_file(sample_code)
-                            sample_kernel = reduce_to_section(sample_parsed, "AArch64", None)
+                            sample_kernel = reduce_to_section(sample_parsed, ParserAArch64())
                             self.assertEqual(len(sample_kernel), kernel_length)
                             kernel_start = len(
                                 list(

--- a/validation/kernels/triad.c
+++ b/validation/kernels/triad.c
@@ -23,11 +23,11 @@ void kernel(DTYPE* a, DTYPE* b, DTYPE* c, const DTYPE s, const int repeat, const
     for(int r=0; r < repeat; r++) {
         for(int i=0; i<cur_elements; i++) {
 #if USE_IACA
-            IACA_VC64_START;
+            IACA_VC64_START
 #endif
             a[i] = b[i] + s * c[i];
 #if USE_IACA
-            IACA_VC64_END;
+            IACA_VC64_END
 #endif
         }
         dummy((void*)a);


### PR DESCRIPTION
This is a complete rewrite of the code.  

The old code was doing a mix of looking at the syntax tree and looking at the source, with the consequence that the processing was very specific and rather messy.  It also had `if` statements based on the ISA and it was parsing literals itself assuming that it knew the syntax of the assembly.  (You can tell that someone was not confident that they were getting it right by looking at the number of tests for `bytes`.)

This all falls apart for the Intel syntax.  First, the marker is very different.  Second, the literals cannot just be parsed by calling Python's `int()` function.  So in the new code the parsers define patterns that represent the start and end markers, and the marker search just traverses recursively the two syntax trees until it finds a match (or not).  The code is longer but really simpler and more flexible.  The parser object that was used for building the syntax tree is propagated everywhere so that random pieces of code can ask things like "parse this literal" without having to do `if` statements.