### PR TITLE
Preparatory changes for semantics support

### DIFF
--- a/msvc/OSACA.pyproj
+++ b/msvc/OSACA.pyproj
@@ -5,7 +5,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{88ef9105-2c58-41fe-ad9f-f54c96a7e8b3}</ProjectGuid>
     <ProjectHome>..\</ProjectHome>
-    <StartupFile>tests\test_marker_utils.py</StartupFile>
+    <StartupFile>tests\test_semantics.py</StartupFile>
     <SearchPath />
     <WorkingDirectory>.</WorkingDirectory>
     <OutputPath>.</OutputPath>

--- a/osaca/parser/base_parser.py
+++ b/osaca/parser/base_parser.py
@@ -125,10 +125,10 @@ class BaseParser(object):
     def get_full_reg_name(self, register):
         raise NotImplementedError
 
-    def get_regular_source_operand(self, instruction_form):
+    def get_regular_source_operands(self, instruction_form):
         raise NotImplementedError
 
-    def get_regular_destination_operand(self, instruction_form):
+    def get_regular_destination_operands(self, instruction_form):
         raise NotImplementedError
 
     def normalize_imd(self, imd):

--- a/osaca/parser/base_parser.py
+++ b/osaca/parser/base_parser.py
@@ -125,7 +125,16 @@ class BaseParser(object):
     def get_full_reg_name(self, register):
         raise NotImplementedError
 
+    def get_regular_source_operand(self, instruction_form):
+        raise NotImplementedError
+
+    def get_regular_destination_operand(self, instruction_form):
+        raise NotImplementedError
+
     def normalize_imd(self, imd):
+        raise NotImplementedError
+
+    def normalize_mnemonic(self, mnemonic):
         raise NotImplementedError
 
     def is_reg_dependend_of(self, reg_a, reg_b):

--- a/osaca/parser/parser_AArch64.py
+++ b/osaca/parser/parser_AArch64.py
@@ -613,6 +613,21 @@ class ParserAArch64(BaseParser):
             name += "[" + str(register.index) + "]"
         return name
 
+    def get_regular_source_operands(self, instruction_form):
+        """Get source operand of given instruction form assuming regular src/dst behavior."""
+        # if there is only one operand, assume it is a source operand
+        if len(instruction_form.operands) == 1:
+            return [instruction_form.operands[0]]
+        return [op for op in instruction_form.operands[1:]]
+
+    def get_regular_destination_operands(self, instruction_form):
+        """Get destination operand of given instruction form assuming regular src/dst behavior."""
+        # if there is only one operand, assume no destination
+        if len(instruction_form.operands) == 1:
+            return []
+        # return first operand
+        return instruction_form.operands[:1]
+
     def normalize_imd(self, imd):
         """Normalize immediate to decimal based representation"""
         if isinstance(imd, IdentifierOperand):

--- a/osaca/parser/parser_AArch64.py
+++ b/osaca/parser/parser_AArch64.py
@@ -630,6 +630,19 @@ class ParserAArch64(BaseParser):
         # identifier
         return imd
 
+    def normalize_mnemonic(self, mnemonic):
+        """
+        Normalize a mnemonic by dropping the suffix.
+
+        :param str mnemonic
+        :return str
+        """
+        if "." in mnemonic:
+            # Check for instruction without shape/cc suffix.
+            suffix_start = mnemonic.index(".")
+            return mnemonic[:suffix_start]
+        return mnemonic
+
     def ieee_to_float(self, ieee_val):
         """Convert IEEE representation to python float"""
         exponent = int(ieee_val["exponent"], 10)

--- a/osaca/parser/parser_x86att.py
+++ b/osaca/parser/parser_x86att.py
@@ -418,6 +418,22 @@ class ParserX86ATT(BaseParser):
         # nothing to do
         return register.name
 
+    def get_regular_source_operands(self, instruction_form):
+        """Get source operand of given instruction form assuming regular src/dst behavior."""
+        # if there is only one operand, assume it is a source operand
+        if len(instruction_form.operands) == 1:
+            return [instruction_form.operands[0]]
+        # return all but last operand
+        return [op for op in instruction_form.operands[0:-1]]
+
+    def get_regular_destination_operands(self, instruction_form):
+        """Get destination operand of given instruction form assuming regular src/dst behavior."""
+        # if there is only one operand, assume no destination
+        if len(instruction_form.operands) == 1:
+            return []
+        # return last operand
+        return instruction_form.operands[-1:]
+
     def normalize_imd(self, imd):
         """Normalize immediate to decimal based representation"""
         if isinstance(imd, IdentifierOperand):

--- a/osaca/parser/parser_x86att.py
+++ b/osaca/parser/parser_x86att.py
@@ -17,6 +17,7 @@ from osaca.parser.immediate import ImmediateOperand
 
 class ParserX86ATT(BaseParser):
     _instance = None
+    GAS_SUFFIXES = "bswlqt"
 
     # Singelton pattern, as this is created very many times
     def __new__(cls):
@@ -429,6 +430,18 @@ class ParserX86ATT(BaseParser):
                 return imd.value
         # identifier
         return imd
+
+    def normalize_mnemonic(self, mnemonic):
+        """
+        Normalize a mnemonic by dropping the suffix.
+
+        :param str mnemonic
+        :return str
+        """
+        # Check for instruction without GAS suffix.
+        if mnemonic[-1] in self.GAS_SUFFIXES:
+            return mnemonic[:-1]
+        return mnemonic
 
     def is_flag_dependend_of(self, flag_a, flag_b):
         """Check if ``flag_a`` is dependent on ``flag_b``"""

--- a/osaca/parser/parser_x86intel.py
+++ b/osaca/parser/parser_x86intel.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 import pyparsing as pp
+import re
+import string
 
 from osaca.parser import BaseParser
 from osaca.parser.directive import DirectiveOperand
@@ -514,6 +516,45 @@ class ParserX86Intel(BaseParser):
         except pp.ParseException:
             return None
 
+    def is_basic_gpr(self, register):
+        """Check if register is a basic general purpose register (ebi, rax, ...)"""
+        if any(char.isdigit() for char in register.name) or any(
+            register.name.lower().startswith(x) for x in ["mm", "xmm", "ymm", "zmm"]
+        ):
+            return False
+        return True
+
+    def is_gpr(self, register):
+        """Check if register is a general purpose register"""
+        if register is None:
+            return False
+        if self.is_basic_gpr(register):
+            return True
+        return re.match(r"R([0-9]+)[DWB]?", register.name, re.IGNORECASE)
+
+    def is_vector_register(self, register):
+        """Check if register is a vector register"""
+        if register is None or register.name is None:
+            return False
+        if register.name.rstrip(string.digits).lower() in [
+            "mm",
+            "xmm",
+            "ymm",
+            "zmm",
+        ]:
+            return True
+        return False
+
+    def get_reg_type(self, register):
+        """Get register type"""
+        if register is None:
+            return False
+        if self.is_gpr(register):
+            return "gpr"
+        elif self.is_vector_register(register):
+            return register.name.rstrip(string.digits).lower()
+        raise ValueError
+
     def process_operand(self, operand):
         """Post-process operand"""
         if self.directive_id in operand:
@@ -621,6 +662,21 @@ class ParserX86Intel(BaseParser):
     def process_identifier(self, identifier):
         return IdentifierOperand(name=identifier.name)
 
+    def get_regular_source_operands(self, instruction_form):
+        """Get source operand of given instruction form assuming regular src/dst behavior."""
+        # if there is only one operand, assume it is a source operand
+        if len(instruction_form.operands) == 1:
+            return [instruction_form.operands[0]]
+        return [op for op in instruction_form.operands[1:]]
+
+    def get_regular_destination_operands(self, instruction_form):
+        """Get destination operand of given instruction form assuming regular src/dst behavior."""
+        # if there is only one operand, assume no destination
+        if len(instruction_form.operands) == 1:
+            return []
+        # return first operand
+        return instruction_form.operands[:1]
+
     def normalize_imd(self, imd):
         """Normalize immediate to decimal based representation"""
         if isinstance(imd, IdentifierOperand):
@@ -642,3 +698,6 @@ class ParserX86Intel(BaseParser):
                 return imd.value
         # identifier
         return imd
+
+    def normalize_mnemonic(self, mnemonic):
+        return mnemonic

--- a/osaca/parser/parser_x86intel.py
+++ b/osaca/parser/parser_x86intel.py
@@ -706,3 +706,6 @@ class ParserX86Intel(BaseParser):
             return -value if negative else value
         else:
             return imd.value
+
+    def normalize_mnemonic(self, mnemonic):
+        return mnemonic

--- a/osaca/semantics/arch_semantics.py
+++ b/osaca/semantics/arch_semantics.py
@@ -280,7 +280,7 @@ class ArchSemantics(ISASemantics):
                             #   - all mem operands in src_dst are pre-/post_indexed
                             # since it is no mem store
                             if (
-                                self._isa == "aarch64"
+                                self._parser.isa() == "aarch64"
                                 and not isinstance(
                                     instruction_form.semantic_operands["destination"],
                                     MemoryOperand,
@@ -411,12 +411,13 @@ class ArchSemantics(ISASemantics):
 
     def convert_op_to_reg(self, reg_type, regtype="0"):
         """Create register operand for a memory addressing operand"""
-        if self._isa == "x86":
+        # TODO: Intel
+        if self._parser.isa() == "x86":
             if reg_type == "gpr":
                 register = RegisterOperand(name="r" + str(int(regtype) + 9))
             else:
                 register = RegisterOperand(name=reg_type + regtype)
-        elif self._isa == "aarch64":
+        elif self._parser.isa() == "aarch64":
             register = RegisterOperand(name=regtype, prefix=reg_type)
         return register
 

--- a/osaca/semantics/hw_model.py
+++ b/osaca/semantics/hw_model.py
@@ -79,7 +79,7 @@ class MachineModel(object):
             else:
                 yaml = self._create_yaml_object()
                 # otherwise load
-                with open(self._path, "r") as f:
+                with open(self._path, "r", encoding="utf8") as f:
                     if not lazy:
                         self._data = yaml.load(f)
                     else:

--- a/osaca/semantics/isa_semantics.py
+++ b/osaca/semantics/isa_semantics.py
@@ -87,11 +87,11 @@ class ISASemantics(object):
 
         if assign_default:
             # no irregular operand structure, apply default
-            op_dict["source"] = self._get_regular_source_operands(instruction_form)
-            op_dict["destination"] = self._get_regular_destination_operands(instruction_form)
+            op_dict["source"] = self._parser.get_regular_source_operands(instruction_form)
+            op_dict["destination"] = self._parser.get_regular_destination_operands(instruction_form)
             op_dict["src_dst"] = []
         # post-process pre- and post-indexing for aarch64 memory operands
-        if self._isa == "aarch64":
+        if self._parser.isa() == "aarch64":
             for operand in [op for op in op_dict["source"] if isinstance(op, MemoryOperand)]:
                 post_indexed = operand.post_indexed
                 pre_indexed = operand.pre_indexed
@@ -282,33 +282,6 @@ class ISASemantics(object):
             if isinstance(operand, MemoryOperand):
                 return True
         return False
-
-    def _get_regular_source_operands(self, instruction_form):
-        """Get source operand of given instruction form assuming regular src/dst behavior."""
-        # if there is only one operand, assume it is a source operand
-        if len(instruction_form.operands) == 1:
-            return [instruction_form.operands[0]]
-        if self._isa == "x86":
-            # return all but last operand
-            return [op for op in instruction_form.operands[0:-1]]
-        elif self._isa == "aarch64":
-            return [op for op in instruction_form.operands[1:]]
-        else:
-            raise ValueError("Unsupported ISA {}.".format(self._isa))
-
-    def _get_regular_destination_operands(self, instruction_form):
-        """Get destination operand of given instruction form assuming regular src/dst behavior."""
-        # if there is only one operand, assume no destination
-        if len(instruction_form.operands) == 1:
-            return []
-        if self._isa == "x86":
-            # return last operand
-            return instruction_form.operands[-1:]
-        if self._isa == "aarch64":
-            # return first operand
-            return instruction_form.operands[:1]
-        else:
-            raise ValueError("Unsupported ISA {}.".format(self._isa))
 
     def substitute_mem_address(self, operands):
         """Create memory wildcard for all memory operands"""

--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -38,8 +38,8 @@ class KernelDG(nx.DiGraph):
             self.kernel, timeout, flag_dependencies
         )
 
-    @staticmethod
-    def _extend_path(dst_list, kernel, dg, offset):
+    @classmethod
+    def _extend_path(cls, dst_list, kernel, dg, offset):
         for instr in kernel:
             generator_path = nx.algorithms.simple_paths.all_simple_paths(
                 dg, instr.line_number, instr.line_number + offset

--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -38,7 +38,8 @@ class KernelDG(nx.DiGraph):
             self.kernel, timeout, flag_dependencies
         )
 
-    def _extend_path(self, dst_list, kernel, dg, offset):
+    @staticmethod
+    def _extend_path(dst_list, kernel, dg, offset):
         for instr in kernel:
             generator_path = nx.algorithms.simple_paths.all_simple_paths(
                 dg, instr.line_number, instr.line_number + offset
@@ -138,7 +139,7 @@ class KernelDG(nx.DiGraph):
                 all_paths = manager.list()
                 processes = [
                     Process(
-                        target=self._extend_path,
+                        target=KernelDG._extend_path,
                         args=(all_paths, instr_section, dg, offset),
                     )
                     for instr_section in instrs
@@ -164,9 +165,7 @@ class KernelDG(nx.DiGraph):
                         # terminate running processes
                         for p in processes:
                             if p.is_alive():
-                                # Python 3.6 does not support Process.kill().
-                                # Can be changed to `p.kill()` after EoL (01/22) of Py3.6
-                                os.kill(p.pid, signal.SIGKILL)
+                                p.kill()
                             p.join()
                 all_paths = list(all_paths)
         else:

--- a/tests/test_files/kernel_x86_intel.asm
+++ b/tests/test_files/kernel_x86_intel.asm
@@ -1,0 +1,29 @@
+; Line 27
+	mov	DWORD PTR i$2[rbp], 0
+	jmp	SHORT $LN7@kernel
+$LN5@kernel:
+	mov	eax, DWORD PTR i$2[rbp]
+	inc	eax
+	mov	DWORD PTR i$2[rbp], eax
+$LN7@kernel:
+	mov	eax, DWORD PTR cur_elements$[rbp]
+	cmp	DWORD PTR i$2[rbp], eax
+	jge	SHORT $LN6@kernel
+; Line 28
+	movsxd	rax, DWORD PTR i$2[rbp]
+	movsxd	rcx, DWORD PTR i$2[rbp]
+	movsxd	rdx, DWORD PTR i$2[rbp]
+	mov	r8, QWORD PTR c$[rbp]
+	mov	r9, QWORD PTR d$[rbp]
+	movsd	xmm0, QWORD PTR [r8+rcx*8]
+	mulsd	xmm0, QWORD PTR [r9+rdx*8]
+	mov	rcx, QWORD PTR b$[rbp]
+	movsd	xmm1, QWORD PTR [rcx+rax*8]
+	addsd	xmm1, xmm0
+	movaps	xmm0, xmm1
+	movsxd	rax, DWORD PTR i$2[rbp]
+	mov	rcx, QWORD PTR a$[rbp]
+	movsd	QWORD PTR [rcx+rax*8], xmm0
+; Line 29
+	jmp	SHORT $LN5@kernel
+$LN6@kernel:

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 
 import networkx as nx
 from osaca.osaca import get_unmatched_instruction_ratio
-from osaca.parser import ParserAArch64, ParserX86ATT
+from osaca.parser import ParserAArch64, ParserX86ATT, ParserX86Intel
 from osaca.semantics import (
     INSTR_FLAGS,
     ArchSemantics,
@@ -33,6 +33,7 @@ class TestSemanticTools(unittest.TestCase):
     def setUpClass(cls):
         # set up parser and kernels
         cls.parser_x86_att = ParserX86ATT()
+        cls.parser_x86_intel = ParserX86Intel()
         cls.parser_AArch64 = ParserAArch64()
         with open(cls._find_file("kernel_x86.s")) as f:
             cls.code_x86 = f.read()
@@ -40,6 +41,8 @@ class TestSemanticTools(unittest.TestCase):
             cls.code_x86_memdep = f.read()
         with open(cls._find_file("kernel_x86_long_LCD.s")) as f:
             cls.code_x86_long_LCD = f.read()
+        with open(cls._find_file("kernel_x86_intel.asm")) as f:
+            cls.code_x86_intel = f.read()
         with open(cls._find_file("kernel_aarch64_memdep.s")) as f:
             cls.code_aarch64_memdep = f.read()
         with open(cls._find_file("kernel_aarch64.s")) as f:
@@ -93,6 +96,12 @@ class TestSemanticTools(unittest.TestCase):
             cls.machine_model_csx,
             path_to_yaml=os.path.join(cls.MODULE_DATA_DIR, "isa/x86.yml"),
         )
+        cls.semantics_x86_intel = ISASemantics(cls.parser_x86_intel)
+        cls.semantics_csx_intel = ArchSemantics(
+            cls.parser_x86_intel,
+            cls.machine_model_csx,
+            path_to_yaml=os.path.join(cls.MODULE_DATA_DIR, "isa/x86.yml"),
+        )
         cls.semantics_aarch64 = ISASemantics(cls.parser_AArch64)
         cls.semantics_tx2 = ArchSemantics(
             cls.parser_AArch64,
@@ -115,6 +124,9 @@ class TestSemanticTools(unittest.TestCase):
         for i in range(len(cls.kernel_x86_long_LCD)):
             cls.semantics_csx.assign_src_dst(cls.kernel_x86_long_LCD[i])
             cls.semantics_csx.assign_tp_lt(cls.kernel_x86_long_LCD[i])
+        for i in range(len(cls.kernel_x86_intel)):
+            cls.semantics_csx_intel.assign_src_dst(cls.kernel_x86_intel[i])
+            cls.semantics_csx_intel.assign_tp_lt(cls.kernel_x86_intel[i])
         for i in range(len(cls.kernel_AArch64)):
             cls.semantics_tx2.assign_src_dst(cls.kernel_AArch64[i])
             cls.semantics_tx2.assign_tp_lt(cls.kernel_AArch64[i])

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -266,7 +266,7 @@ class TestSemanticTools(unittest.TestCase):
         test_mm_arm.add_port("dummyPort")
 
         # test dump of DB
-        with open("/dev/null", "w") as dev_null:
+        with open(os.devnull, "w") as dev_null:
             test_mm_x86.dump(stream=dev_null)
             test_mm_arm.dump(stream=dev_null)
 
@@ -375,7 +375,7 @@ class TestSemanticTools(unittest.TestCase):
         with self.assertRaises(ValueError):
             dg.get_dependent_instruction_forms()
         # test dot creation
-        dg.export_graph(filepath="/dev/null")
+        dg.export_graph(filepath=os.devnull)
 
     def test_memdependency_x86(self):
         dg = KernelDG(
@@ -390,7 +390,7 @@ class TestSemanticTools(unittest.TestCase):
         with self.assertRaises(ValueError):
             dg.get_dependent_instruction_forms()
         # test dot creation
-        dg.export_graph(filepath="/dev/null")
+        dg.export_graph(filepath=os.devnull)
 
     def test_kernelDG_AArch64(self):
         dg = KernelDG(
@@ -421,7 +421,7 @@ class TestSemanticTools(unittest.TestCase):
         with self.assertRaises(ValueError):
             dg.get_dependent_instruction_forms()
         # test dot creation
-        dg.export_graph(filepath="/dev/null")
+        dg.export_graph(filepath=os.devnull)
 
     def test_kernelDG_SVE(self):
         KernelDG(

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -437,7 +437,7 @@ class TestSemanticTools(unittest.TestCase):
             path_to_yaml=self._find_file("hidden_load_machine_model.yml")
         )
         self.assertTrue(machine_model_hld.has_hidden_loads())
-        semantics_hld = ArchSemantics(machine_model_hld)
+        semantics_hld = ArchSemantics(self.parser_x86_att, machine_model_hld)
         kernel_hld = self.parser_x86_att.parse_file(self.code_x86)
         kernel_hld_2 = self.parser_x86_att.parse_file(self.code_x86)
         kernel_hld_2 = self.parser_x86_att.parse_file(self.code_x86)[-3:]

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -135,7 +135,7 @@ class TestSemanticTools(unittest.TestCase):
     def test_creation_by_name(self):
         try:
             tmp_mm = MachineModel(arch="CSX")
-            ArchSemantics(tmp_mm)
+            ArchSemantics(self.parser_x86_att, tmp_mm)
         except ValueError:
             self.fail()
 
@@ -320,7 +320,7 @@ class TestSemanticTools(unittest.TestCase):
         self.assertTrue(max(tp_optimal) <= max(tp_fixed))
         # test multiple port assignment options
         test_mm_x86 = MachineModel(path_to_yaml=self._find_file("test_db_x86.yml"))
-        tmp_semantics = ArchSemantics(test_mm_x86)
+        tmp_semantics = ArchSemantics(self.parser_x86_att, test_mm_x86)
         tmp_code_1 = "fantasyinstr1 %rax, %rax\n"
         tmp_code_2 = "fantasyinstr1 %rax, %rax\nfantasyinstr2 %rbx, %rbx\n"
         tmp_kernel_1 = self.parser_x86_att.parse_file(tmp_code_1)

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -63,6 +63,10 @@ class TestSemanticTools(unittest.TestCase):
             cls.parser_x86_att.parse_file(cls.code_x86_long_LCD),
             cls.parser_x86_att
         )
+        cls.kernel_x86_intel = reduce_to_section(
+            cls.parser_x86_intel.parse_file(cls.code_x86_intel),
+            cls.parser_x86_intel
+        )
         cls.kernel_AArch64 = reduce_to_section(
             cls.parser_AArch64.parse_file(cls.code_AArch64),
             cls.parser_AArch64

--- a/validation/kernels/striad.c
+++ b/validation/kernels/striad.c
@@ -7,6 +7,12 @@
 #endif
 #endif
 
+#define USE_IACA 1
+
+#if USE_IACA
+#include "intel\iacaMarks.h"
+#endif
+
 #define DTYPE double
 
 void dummy(void *);
@@ -15,9 +21,15 @@ void kernel(DTYPE* a, DTYPE* b, DTYPE* c, DTYPE* d, const int repeat, const int 
 #ifndef MAIN
 {
     for(int r=0; r < repeat; r++) {
+#if USE_IACA
+            IACA_VC64_START
+#endif
         for(int i=0; i<cur_elements; i++) {
             a[i] = b[i] + c[i] * d[i];
         }
+#if USE_IACA
+            IACA_VC64_END
+#endif
         dummy((void*)a);
     }
 }


### PR DESCRIPTION
1. Add utility functions to the parser to delegate some of the semantics decisions to the parser.  This removes a bunch of `if` statements.
2. Implement some missing utilities in the Intel parser.  These are just copied from the AT&T parser, so it would probably make sense to have an x86 superclass at some point.
3. Pass the parser, not the ISA string, to the semantics classes, including the test.
4. Add an Intel assembly file suitable for semantics testing.
5. Fix OS dependencies and a strange pickling error.