### PR TITLE
Add three more test to check Intel semantics

### DIFF
--- a/osaca/parser/base_parser.py
+++ b/osaca/parser/base_parser.py
@@ -48,10 +48,11 @@ class BaseParser(object):
         # Done in derived classes
         raise NotImplementedError
 
-    # Performs all the normalization needed to match the instructions to the ISO/arch model.
-    def normalize_instruction_forms(
+    # Performs all the normalization needed to match the instruction to the ISO/arch model.  This
+    # method must set the `normalized` property of the instruction and must be idempotent.
+    def normalize_instruction_form(
         self,
-        instruction_forms,
+        instruction_form,
         isa_model: MachineModel,
         arch_model: MachineModel
     ):

--- a/osaca/parser/instruction_form.py
+++ b/osaca/parser/instruction_form.py
@@ -19,6 +19,7 @@ class InstructionForm:
         port_pressure=None,
         operation=None,
         breaks_dependency_on_equal_operands=False,
+        normalized=False,
     ):
         self._mnemonic = mnemonic
         self._operands = operands
@@ -33,6 +34,7 @@ class InstructionForm:
         self._operation = operation
         self._uops = uops
         self._breaks_dependency_on_equal_operands = breaks_dependency_on_equal_operands
+        self._normalized = normalized
         self._latency = latency
         self._throughput = throughput
         self._latency_cp = []
@@ -114,6 +116,10 @@ class InstructionForm:
     def breaks_dependency_on_equal_operands(self):
         return self._breaks_dependency_on_equal_operands
 
+    @property
+    def normalized(self):
+        return self._normalized
+
     @semantic_operands.setter
     def semantic_operands(self, semantic_operands):
         self._semantic_operands = semantic_operands
@@ -141,6 +147,10 @@ class InstructionForm:
     @breaks_dependency_on_equal_operands.setter
     def breaks_dependency_on_equal_operands(self, boolean):
         self._breaks_dependency_on_equal_operands = boolean
+
+    @normalized.setter
+    def normalized(self, normalized):
+        self._normalized = normalized
 
     @mnemonic.setter
     def mnemonic(self, mnemonic):

--- a/osaca/parser/instruction_form.py
+++ b/osaca/parser/instruction_form.py
@@ -44,6 +44,10 @@ class InstructionForm:
         self._port_uops = []
         self._flags = []
 
+    def check_normalized(self):
+        if not self._normalized:
+            raise AssertionError("Unnormalized instruction")
+
     @property
     def semantic_operands(self):
         return self._semantic_operands

--- a/osaca/parser/parser_AArch64.py
+++ b/osaca/parser/parser_AArch64.py
@@ -53,9 +53,9 @@ class ParserAArch64(BaseParser):
             )
         ]
 
-    def normalize_instruction_forms(
+    def normalize_instruction_form(
         self,
-        instruction_forms,
+        instruction_form,
         isa_model: MachineModel,
         arch_model: MachineModel
     ):
@@ -63,19 +63,22 @@ class ParserAArch64(BaseParser):
         If the instruction doesn't exist in the machine model, normalize it by dropping the shape
         suffix.
         """
-        for instruction_form in instruction_forms:
-            mnemonic = instruction_form.mnemonic
-            if not mnemonic:
-                continue
-            model = arch_model.get_instruction(mnemonic, instruction_form.operands)
-            if not model:
-                if "." in mnemonic:
-                    # Check for instruction without shape/cc suffix.
-                    suffix_start = mnemonic.index(".")
-                    mnemonic = mnemonic[:suffix_start]
-                    model = arch_model.get_instruction(mnemonic, instruction_form.operands)
-                    if model:
-                        instruction_form.mnemonic = mnemonic
+        if instruction_form.normalized:
+            return
+        instruction_form.normalized = True
+
+        mnemonic = instruction_form.mnemonic
+        if not mnemonic:
+            return
+        model = arch_model.get_instruction(mnemonic, instruction_form.operands)
+        if not model:
+            if "." in mnemonic:
+                # Check for instruction without shape/cc suffix.
+                suffix_start = mnemonic.index(".")
+                mnemonic = mnemonic[:suffix_start]
+                model = arch_model.get_instruction(mnemonic, instruction_form.operands)
+                if model:
+                    instruction_form.mnemonic = mnemonic
 
     def construct_parser(self):
         """Create parser for ARM AArch64 ISA."""

--- a/osaca/parser/parser_x86att.py
+++ b/osaca/parser/parser_x86att.py
@@ -63,9 +63,9 @@ class ParserX86ATT(ParserX86):
             )
         ]
 
-    def normalize_instruction_forms(
+    def normalize_instruction_form(
         self,
-        instruction_forms,
+        instruction_form,
         isa_model: MachineModel,
         arch_model: MachineModel
     ):
@@ -73,18 +73,21 @@ class ParserX86ATT(ParserX86):
         If the instruction doesn't exist in the machine model, normalize it by dropping the GAS
         suffix.
         """
-        for instruction_form in instruction_forms:
-            mnemonic = instruction_form.mnemonic
-            if not mnemonic:
-                continue
-            model = arch_model.get_instruction(mnemonic, instruction_form.operands)
-            if not model:
-                # Check for instruction without GAS suffix.
-                if mnemonic[-1] in self.GAS_SUFFIXES:
-                    mnemonic = mnemonic[:-1]
-                    model = arch_model.get_instruction(mnemonic, instruction_form.operands)
-                    if model:
-                        instruction_form.mnemonic = mnemonic
+        if instruction_form.normalized:
+            return
+        instruction_form.normalized = True
+
+        mnemonic = instruction_form.mnemonic
+        if not mnemonic:
+            return
+        model = arch_model.get_instruction(mnemonic, instruction_form.operands)
+        if not model:
+            # Check for instruction without GAS suffix.
+            if mnemonic[-1] in self.GAS_SUFFIXES:
+                mnemonic = mnemonic[:-1]
+                model = arch_model.get_instruction(mnemonic, instruction_form.operands)
+                if model:
+                    instruction_form.mnemonic = mnemonic
 
     def construct_parser(self):
         """Create parser for x86 AT&T ISA."""

--- a/osaca/parser/parser_x86intel.py
+++ b/osaca/parser/parser_x86intel.py
@@ -105,6 +105,8 @@ class ParserX86Intel(ParserX86):
             else:
                 # if there is only one operand, assume it is a source operand
                 has_single_destination_at_end = len(instruction_form.operands) > 1
+            # TODO: This doesn't do the right thing for vinsertf128, the immediate operand is first
+            # in the AT&T syntax and last in the Intel syntax.
             if has_single_destination_at_end:
                 sources = instruction_form.operands[1:]
                 destination = instruction_form.operands[0]

--- a/osaca/semantics/isa_semantics.py
+++ b/osaca/semantics/isa_semantics.py
@@ -41,6 +41,7 @@ class ISASemantics(object):
     def process(self, instruction_forms):
         """Process a list of instruction forms."""
         for i in instruction_forms:
+            i.check_normalized()
             self.assign_src_dst(i)
 
     # get ;parser result and assign operands to
@@ -49,6 +50,7 @@ class ISASemantics(object):
     # - source/destination
     def assign_src_dst(self, instruction_form):
         """Update instruction form dictionary with source, destination and flag information."""
+        instruction_form.check_normalized()
         # if the instruction form doesn't have operands or is None, there's nothing to do
         if instruction_form.operands is None or instruction_form.mnemonic is None:
             instruction_form.semantic_operands = {"source": [], "destination": [], "src_dst": []}
@@ -128,6 +130,7 @@ class ISASemantics(object):
         Empty dict if no changes of registers occured. None for registers with unknown changes.
         If only_postindexed is True, only considers changes due to post_indexed memory references.
         """
+        instruction_form.check_normalized()
         if instruction_form.mnemonic is None:
             return {}
         dest_reg_names = [
@@ -253,6 +256,7 @@ class ISASemantics(object):
 
     def _has_load(self, instruction_form):
         """Check if instruction form performs a LOAD"""
+        instruction_form.check_normalized()
         for operand in chain(
             instruction_form.semantic_operands["source"],
             instruction_form.semantic_operands["src_dst"],
@@ -263,6 +267,7 @@ class ISASemantics(object):
 
     def _has_store(self, instruction_form):
         """Check if instruction form perfroms a STORE"""
+        instruction_form.check_normalized()
         for operand in chain(
             instruction_form.semantic_operands["destination"],
             instruction_form.semantic_operands["src_dst"],

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -358,8 +358,7 @@ class TestSemanticTools(unittest.TestCase):
                 self.assertIsInstance(instruction_form.port_pressure, list)
                 self.assertEqual(len(instruction_form.port_pressure), port_num)
 
-    def test_optimal_throughput_assignment(self):
-        # x86
+    def test_optimal_throughput_assignment_x86(self):
         kernel_fixed = deepcopy(self.kernel_x86)
         self.semantics_csx.add_semantics(kernel_fixed)
         self.assertEqual(get_unmatched_instruction_ratio(kernel_fixed), 0)
@@ -386,9 +385,34 @@ class TestSemanticTools(unittest.TestCase):
         self.assertEqual(k1i1_pp, [0.33, 0.0, 0.33, 0.0, 0.0, 0.0, 0.0, 0.0, 0.33, 0.0, 0.0])
         self.assertEqual(k2i1_pp, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0])
 
-        # TODO x86 Intel
+    def test_optimal_throughput_assignment_x86_intel(self):
+        kernel_fixed = deepcopy(self.kernel_x86_intel)
+        self.semantics_csx_intel.add_semantics(kernel_fixed)
+        self.assertEqual(get_unmatched_instruction_ratio(kernel_fixed), 0)
 
-        # arm
+        kernel_optimal = deepcopy(kernel_fixed)
+        self.semantics_csx_intel.assign_optimal_throughput(kernel_optimal)
+        tp_fixed = self.semantics_csx_intel.get_throughput_sum(kernel_fixed)
+        tp_optimal = self.semantics_csx_intel.get_throughput_sum(kernel_optimal)
+        self.assertNotEqual(tp_fixed, tp_optimal)
+        self.assertTrue(max(tp_optimal) <= max(tp_fixed))
+        # test multiple port assignment options
+        test_mm_x86 = MachineModel(path_to_yaml=self._find_file("test_db_x86.yml"))
+        tmp_semantics = ArchSemantics(self.parser_x86_intel, test_mm_x86)
+        tmp_code_1 = "fantasyinstr1 rax, rax\n"
+        tmp_code_2 = "fantasyinstr1 rax, rax\nfantasyinstr2 rbx, rbx\n"
+        tmp_kernel_1 = self.parser_x86_intel.parse_file(tmp_code_1)
+        tmp_kernel_2 = self.parser_x86_intel.parse_file(tmp_code_2)
+        tmp_semantics.add_semantics(tmp_kernel_1)
+        tmp_semantics.add_semantics(tmp_kernel_2)
+        tmp_semantics.assign_optimal_throughput(tmp_kernel_1)
+        tmp_semantics.assign_optimal_throughput(tmp_kernel_2)
+        k1i1_pp = [round(x, 2) for x in tmp_kernel_1[0].port_pressure]
+        k2i1_pp = [round(x, 2) for x in tmp_kernel_2[0].port_pressure]
+        self.assertEqual(k1i1_pp, [0.33, 0.0, 0.33, 0.0, 0.0, 0.0, 0.0, 0.0, 0.33, 0.0, 0.0])
+        self.assertEqual(k2i1_pp, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0])
+
+    def test_optimal_throughput_assignment_AArch64(self):
         kernel_fixed = deepcopy(self.kernel_AArch64)
         self.semantics_tx2.add_semantics(kernel_fixed)
 
@@ -656,6 +680,39 @@ class TestSemanticTools(unittest.TestCase):
             dg.dg.nodes(data=True)[int(lcd_id2)]["instruction_form"],
         )
 
+    def test_loop_carried_dependency_x86_intel(self):
+        lcd_id = "8"
+        lcd_id2 = "7"
+        dg = KernelDG(
+            self.kernel_x86_intel,
+            self.parser_x86_intel,
+            self.machine_model_csx,
+            self.semantics_csx_intel
+        )
+        lc_deps = dg.get_loopcarried_dependencies()
+        # self.assertEqual(len(lc_deps), 2)
+        # ID 8
+        self.assertEqual(
+            lc_deps[lcd_id]["root"], dg.dg.nodes(data=True)[int(lcd_id)]["instruction_form"]
+        )
+        self.assertEqual(len(lc_deps[lcd_id]["dependencies"]), 1)
+        self.assertEqual(
+            lc_deps[lcd_id]["dependencies"][0][0],
+            dg.dg.nodes(data=True)[int(lcd_id)]["instruction_form"],
+        )
+        # w/  flag dependencies: ID 9 w/ len=2
+        # w/o flag dependencies: ID 5 w/ len=1
+        # TODO discuss
+        self.assertEqual(
+            lc_deps[lcd_id2]["root"],
+            dg.dg.nodes(data=True)[int(lcd_id2)]["instruction_form"],
+        )
+        self.assertEqual(len(lc_deps[lcd_id2]["dependencies"]), 1)
+        self.assertEqual(
+            lc_deps[lcd_id2]["dependencies"][0][0],
+            dg.dg.nodes(data=True)[int(lcd_id2)]["instruction_form"],
+        )
+
     def test_timeout_during_loop_carried_dependency(self):
         start_time = time.perf_counter()
         KernelDG(
@@ -705,6 +762,47 @@ class TestSemanticTools(unittest.TestCase):
         self.semantics_csx.assign_src_dst(instr_form_rw_ymm_2)
         instr_form_r_ymm = self.parser_x86_att.parse_line("vmovapd %ymm1, %ymm0")
         self.semantics_csx.assign_src_dst(instr_form_r_ymm)
+        self.assertTrue(dag.is_read(reg_rcx, instr_form_r_c))
+        self.assertFalse(dag.is_read(reg_rcx, instr_form_non_r_c))
+        self.assertFalse(dag.is_read(reg_rcx, instr_form_w_c))
+        self.assertTrue(dag.is_written(reg_rcx, instr_form_w_c))
+        self.assertFalse(dag.is_written(reg_rcx, instr_form_r_c))
+        self.assertTrue(dag.is_read(reg_ymm1, instr_form_rw_ymm_1))
+        self.assertTrue(dag.is_read(reg_ymm1, instr_form_rw_ymm_2))
+        self.assertTrue(dag.is_read(reg_ymm1, instr_form_r_ymm))
+        self.assertTrue(dag.is_written(reg_ymm1, instr_form_rw_ymm_1))
+        self.assertTrue(dag.is_written(reg_ymm1, instr_form_rw_ymm_2))
+        self.assertFalse(dag.is_written(reg_ymm1, instr_form_r_ymm))
+
+    def test_is_read_is_written_x86_intel(self):
+        # independent form HW model
+        dag = KernelDG(self.kernel_x86_intel, self.parser_x86_intel, None, None)
+        reg_rcx = RegisterOperand(name="rcx")
+        reg_ymm1 = RegisterOperand(name="ymm1")
+
+        instr_form_r_c = self.parser_x86_intel.parse_line("vmovsd  QWORD PTR [r15+rcx*8], xmm0")
+        self.semantics_csx_intel.normalize_kernel([instr_form_r_c])
+        self.semantics_csx_intel.assign_src_dst(instr_form_r_c)
+        instr_form_non_r_c = self.parser_x86_intel.parse_line("mov  QWORD PTR [r15+rax*8], xmm0")
+        self.semantics_csx_intel.normalize_kernel([instr_form_non_r_c])
+        self.semantics_csx_intel.assign_src_dst(instr_form_non_r_c)
+        instr_form_w_c = self.parser_x86_intel.parse_line("mov rcx, H05ACA")
+        self.semantics_csx_intel.normalize_kernel([instr_form_w_c])
+        self.semantics_csx_intel.assign_src_dst(instr_form_w_c)
+
+        instr_form_rw_ymm_1 = self.parser_x86_intel.parse_line(
+            "vinsertf128 ymm1, ymm0, xmm1, 1"
+        )
+        self.semantics_csx_intel.normalize_kernel([instr_form_rw_ymm_1])
+        self.semantics_csx_intel.assign_src_dst(instr_form_rw_ymm_1)
+        instr_form_rw_ymm_2 = self.parser_x86_intel.parse_line(
+            "vinsertf128 ymm1, ymm1, xmm0, 1"
+        )
+        self.semantics_csx_intel.normalize_kernel([instr_form_rw_ymm_2])
+        self.semantics_csx_intel.assign_src_dst(instr_form_rw_ymm_2)
+        instr_form_r_ymm = self.parser_x86_intel.parse_line("vmovapd ymm0, ymm1")
+        self.semantics_csx_intel.normalize_kernel([instr_form_r_ymm])
+        self.semantics_csx_intel.assign_src_dst(instr_form_r_ymm)
         self.assertTrue(dag.is_read(reg_rcx, instr_form_r_c))
         self.assertFalse(dag.is_read(reg_rcx, instr_form_non_r_c))
         self.assertFalse(dag.is_read(reg_rcx, instr_form_w_c))

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -125,39 +125,39 @@ class TestSemanticTools(unittest.TestCase):
         )
         cls.machine_model_zen = MachineModel(arch="zen1")
 
-        cls.semantics_csx.normalize_kernel(cls.kernel_x86)
+        cls.semantics_csx.normalize_instruction_forms(cls.kernel_x86)
         for i in range(len(cls.kernel_x86)):
             cls.semantics_csx.assign_src_dst(cls.kernel_x86[i])
             cls.semantics_csx.assign_tp_lt(cls.kernel_x86[i])
-        cls.semantics_csx.normalize_kernel(cls.kernel_x86_memdep)
+        cls.semantics_csx.normalize_instruction_forms(cls.kernel_x86_memdep)
         for i in range(len(cls.kernel_x86_memdep)):
             cls.semantics_csx.assign_src_dst(cls.kernel_x86_memdep[i])
             cls.semantics_csx.assign_tp_lt(cls.kernel_x86_memdep[i])
-        cls.semantics_csx.normalize_kernel(cls.kernel_x86_long_LCD)
+        cls.semantics_csx.normalize_instruction_forms(cls.kernel_x86_long_LCD)
         for i in range(len(cls.kernel_x86_long_LCD)):
             cls.semantics_csx.assign_src_dst(cls.kernel_x86_long_LCD[i])
             cls.semantics_csx.assign_tp_lt(cls.kernel_x86_long_LCD[i])
-        cls.semantics_csx_intel.normalize_kernel(cls.kernel_x86_intel)
+        cls.semantics_csx_intel.normalize_instruction_forms(cls.kernel_x86_intel)
         for i in range(len(cls.kernel_x86_intel)):
             cls.semantics_csx_intel.assign_src_dst(cls.kernel_x86_intel[i])
             cls.semantics_csx_intel.assign_tp_lt(cls.kernel_x86_intel[i])
-        cls.semantics_csx_intel.normalize_kernel(cls.kernel_x86_intel_memdep)
+        cls.semantics_csx_intel.normalize_instruction_forms(cls.kernel_x86_intel_memdep)
         for i in range(len(cls.kernel_x86_intel_memdep)):
             cls.semantics_csx_intel.assign_src_dst(cls.kernel_x86_intel_memdep[i])
             cls.semantics_csx_intel.assign_tp_lt(cls.kernel_x86_intel_memdep[i])
-        cls.semantics_tx2.normalize_kernel(cls.kernel_AArch64)
+        cls.semantics_tx2.normalize_instruction_forms(cls.kernel_AArch64)
         for i in range(len(cls.kernel_AArch64)):
             cls.semantics_tx2.assign_src_dst(cls.kernel_AArch64[i])
             cls.semantics_tx2.assign_tp_lt(cls.kernel_AArch64[i])
-        cls.semantics_tx2.normalize_kernel(cls.kernel_aarch64_memdep)
+        cls.semantics_tx2.normalize_instruction_forms(cls.kernel_aarch64_memdep)
         for i in range(len(cls.kernel_aarch64_memdep)):
             cls.semantics_tx2.assign_src_dst(cls.kernel_aarch64_memdep[i])
             cls.semantics_tx2.assign_tp_lt(cls.kernel_aarch64_memdep[i])
-        cls.semantics_a64fx.normalize_kernel(cls.kernel_aarch64_SVE)
+        cls.semantics_a64fx.normalize_instruction_forms(cls.kernel_aarch64_SVE)
         for i in range(len(cls.kernel_aarch64_SVE)):
             cls.semantics_a64fx.assign_src_dst(cls.kernel_aarch64_SVE[i])
             cls.semantics_a64fx.assign_tp_lt(cls.kernel_aarch64_SVE[i])
-        cls.semantics_a64fx.normalize_kernel(cls.kernel_aarch64_deps)
+        cls.semantics_a64fx.normalize_instruction_forms(cls.kernel_aarch64_deps)
         for i in range(len(cls.kernel_aarch64_deps)):
             cls.semantics_a64fx.assign_src_dst(cls.kernel_aarch64_deps[i])
             cls.semantics_a64fx.assign_tp_lt(cls.kernel_aarch64_deps[i])
@@ -376,6 +376,8 @@ class TestSemanticTools(unittest.TestCase):
         tmp_code_2 = "fantasyinstr1 %rax, %rax\nfantasyinstr2 %rbx, %rbx\n"
         tmp_kernel_1 = self.parser_x86_att.parse_file(tmp_code_1)
         tmp_kernel_2 = self.parser_x86_att.parse_file(tmp_code_2)
+        tmp_semantics.normalize_instruction_forms(tmp_kernel_1)
+        tmp_semantics.normalize_instruction_forms(tmp_kernel_2)
         tmp_semantics.add_semantics(tmp_kernel_1)
         tmp_semantics.add_semantics(tmp_kernel_2)
         tmp_semantics.assign_optimal_throughput(tmp_kernel_1)
@@ -403,6 +405,8 @@ class TestSemanticTools(unittest.TestCase):
         tmp_code_2 = "fantasyinstr1 rax, rax\nfantasyinstr2 rbx, rbx\n"
         tmp_kernel_1 = self.parser_x86_intel.parse_file(tmp_code_1)
         tmp_kernel_2 = self.parser_x86_intel.parse_file(tmp_code_2)
+        tmp_semantics.normalize_instruction_forms(tmp_kernel_1)
+        tmp_semantics.normalize_instruction_forms(tmp_kernel_2)
         tmp_semantics.add_semantics(tmp_kernel_1)
         tmp_semantics.add_semantics(tmp_kernel_2)
         tmp_semantics.assign_optimal_throughput(tmp_kernel_1)
@@ -567,6 +571,10 @@ class TestSemanticTools(unittest.TestCase):
         kernel_hld_2 = self.parser_x86_att.parse_file(self.code_x86)
         kernel_hld_2 = self.parser_x86_att.parse_file(self.code_x86)[-3:]
         kernel_hld_3 = self.parser_x86_att.parse_file(self.code_x86)[5:8]
+
+        semantics_hld.normalize_instruction_forms(kernel_hld)
+        semantics_hld.normalize_instruction_forms(kernel_hld_2)
+        semantics_hld.normalize_instruction_forms(kernel_hld_3)
 
         semantics_hld.add_semantics(kernel_hld)
         semantics_hld.add_semantics(kernel_hld_2)
@@ -746,21 +754,27 @@ class TestSemanticTools(unittest.TestCase):
         reg_ymm1 = RegisterOperand(name="ymm1")
 
         instr_form_r_c = self.parser_x86_att.parse_line("vmovsd  %xmm0, (%r15,%rcx,8)")
+        self.semantics_csx.normalize_instruction_form(instr_form_r_c)
         self.semantics_csx.assign_src_dst(instr_form_r_c)
         instr_form_non_r_c = self.parser_x86_att.parse_line("movl  %xmm0, (%r15,%rax,8)")
+        self.semantics_csx.normalize_instruction_form(instr_form_non_r_c)
         self.semantics_csx.assign_src_dst(instr_form_non_r_c)
         instr_form_w_c = self.parser_x86_att.parse_line("movi $0x05ACA, %rcx")
+        self.semantics_csx.normalize_instruction_form(instr_form_w_c)
         self.semantics_csx.assign_src_dst(instr_form_w_c)
 
         instr_form_rw_ymm_1 = self.parser_x86_att.parse_line(
             "vinsertf128 $0x1, %xmm1, %ymm0, %ymm1"
         )
+        self.semantics_csx.normalize_instruction_form(instr_form_rw_ymm_1)
         self.semantics_csx.assign_src_dst(instr_form_rw_ymm_1)
         instr_form_rw_ymm_2 = self.parser_x86_att.parse_line(
             "vinsertf128 $0x1, %xmm0, %ymm1, %ymm1"
         )
+        self.semantics_csx.normalize_instruction_form(instr_form_rw_ymm_2)
         self.semantics_csx.assign_src_dst(instr_form_rw_ymm_2)
         instr_form_r_ymm = self.parser_x86_att.parse_line("vmovapd %ymm1, %ymm0")
+        self.semantics_csx.normalize_instruction_form(instr_form_r_ymm)
         self.semantics_csx.assign_src_dst(instr_form_r_ymm)
         self.assertTrue(dag.is_read(reg_rcx, instr_form_r_c))
         self.assertFalse(dag.is_read(reg_rcx, instr_form_non_r_c))
@@ -781,27 +795,27 @@ class TestSemanticTools(unittest.TestCase):
         reg_ymm1 = RegisterOperand(name="ymm1")
 
         instr_form_r_c = self.parser_x86_intel.parse_line("vmovsd  QWORD PTR [r15+rcx*8], xmm0")
-        self.semantics_csx_intel.normalize_kernel([instr_form_r_c])
+        self.semantics_csx_intel.normalize_instruction_form(instr_form_r_c)
         self.semantics_csx_intel.assign_src_dst(instr_form_r_c)
         instr_form_non_r_c = self.parser_x86_intel.parse_line("mov  QWORD PTR [r15+rax*8], xmm0")
-        self.semantics_csx_intel.normalize_kernel([instr_form_non_r_c])
+        self.semantics_csx_intel.normalize_instruction_form(instr_form_non_r_c)
         self.semantics_csx_intel.assign_src_dst(instr_form_non_r_c)
         instr_form_w_c = self.parser_x86_intel.parse_line("mov rcx, H05ACA")
-        self.semantics_csx_intel.normalize_kernel([instr_form_w_c])
+        self.semantics_csx_intel.normalize_instruction_form(instr_form_w_c)
         self.semantics_csx_intel.assign_src_dst(instr_form_w_c)
 
         instr_form_rw_ymm_1 = self.parser_x86_intel.parse_line(
             "vinsertf128 ymm1, ymm0, xmm1, 1"
         )
-        self.semantics_csx_intel.normalize_kernel([instr_form_rw_ymm_1])
+        self.semantics_csx_intel.normalize_instruction_form(instr_form_rw_ymm_1)
         self.semantics_csx_intel.assign_src_dst(instr_form_rw_ymm_1)
         instr_form_rw_ymm_2 = self.parser_x86_intel.parse_line(
             "vinsertf128 ymm1, ymm1, xmm0, 1"
         )
-        self.semantics_csx_intel.normalize_kernel([instr_form_rw_ymm_2])
+        self.semantics_csx_intel.normalize_instruction_form(instr_form_rw_ymm_2)
         self.semantics_csx_intel.assign_src_dst(instr_form_rw_ymm_2)
         instr_form_r_ymm = self.parser_x86_intel.parse_line("vmovapd ymm0, ymm1")
-        self.semantics_csx_intel.normalize_kernel([instr_form_r_ymm])
+        self.semantics_csx_intel.normalize_instruction_form(instr_form_r_ymm)
         self.semantics_csx_intel.assign_src_dst(instr_form_r_ymm)
         self.assertTrue(dag.is_read(reg_rcx, instr_form_r_c))
         self.assertFalse(dag.is_read(reg_rcx, instr_form_non_r_c))
@@ -827,20 +841,28 @@ class TestSemanticTools(unittest.TestCase):
         regs_gp = [reg_w1, reg_x1]
 
         instr_form_r_1 = self.parser_AArch64.parse_line("stp q1, q3, [x12, #192]")
+        self.semantics_tx2.normalize_instruction_form(instr_form_r_1)
         self.semantics_tx2.assign_src_dst(instr_form_r_1)
         instr_form_r_2 = self.parser_AArch64.parse_line("fadd v2.2d, v1.2d, v0.2d")
+        self.semantics_tx2.normalize_instruction_form(instr_form_r_2)
         self.semantics_tx2.assign_src_dst(instr_form_r_2)
         instr_form_w_1 = self.parser_AArch64.parse_line("ldr d1, [x1, #:got_lo12:q2c]")
+        self.semantics_tx2.normalize_instruction_form(instr_form_w_1)
         self.semantics_tx2.assign_src_dst(instr_form_w_1)
         instr_form_non_w_1 = self.parser_AArch64.parse_line("ldr x1, [x1, #:got_lo12:q2c]")
+        self.semantics_tx2.normalize_instruction_form(instr_form_non_w_1)
         self.semantics_tx2.assign_src_dst(instr_form_non_w_1)
         instr_form_rw_1 = self.parser_AArch64.parse_line("fmul v1.2d, v1.2d, v0.2d")
+        self.semantics_tx2.normalize_instruction_form(instr_form_rw_1)
         self.semantics_tx2.assign_src_dst(instr_form_rw_1)
         instr_form_rw_2 = self.parser_AArch64.parse_line("ldp q2, q4, [x1, #64]!")
+        self.semantics_tx2.normalize_instruction_form(instr_form_rw_2)
         self.semantics_tx2.assign_src_dst(instr_form_rw_2)
         instr_form_rw_3 = self.parser_AArch64.parse_line("str x4, [x1], #64")
+        self.semantics_tx2.normalize_instruction_form(instr_form_rw_3)
         self.semantics_tx2.assign_src_dst(instr_form_rw_3)
         instr_form_non_rw_1 = self.parser_AArch64.parse_line("adds x1, x11")
+        self.semantics_tx2.normalize_instruction_form(instr_form_non_rw_1)
         self.semantics_tx2.assign_src_dst(instr_form_non_rw_1)
 
         for reg in regs:


### PR DESCRIPTION
Also clean up instruction normalization: the semantics checks that instructions are normalized, and the caller is expected to do the normalization in between parsing and semantics.