### PR TITLE
More improvements based on running on real code

### DIFF
--- a/osaca/parser/parser_x86intel.py
+++ b/osaca/parser/parser_x86intel.py
@@ -334,7 +334,7 @@ class ParserX86Intel(ParserX86):
             self.register.setResultsName("segment") + pp.Literal(":") + immediate
             ^ immediate + register_expression
             ^ register_expression
-            ^ identifier + pp.Literal("+") + immediate
+            ^ identifier + pp.Optional(pp.Literal("+") + immediate)
         ).setResultsName("address_expression")
 
         offset_expression = pp.Group(

--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -185,11 +185,11 @@ class KernelDG(nx.DiGraph):
             for s, d in nx.utils.pairwise(path):
                 edge_lat = dg.edges[s, d]["latency"]
                 # map source node back to original line numbers
-                if s >= offset:
+                if s > offset:
                     s -= offset
                 lat_path.append((s, edge_lat))
                 lat_sum += edge_lat
-            if d >= offset:
+            if d > offset:
                 d -= offset
             lat_path.sort()
 

--- a/tests/test_parser_x86intel.py
+++ b/tests/test_parser_x86intel.py
@@ -93,6 +93,7 @@ class TestParserX86Intel(unittest.TestCase):
         instr10 = "\tmovsd\txmm1, QWORD PTR boost@@XZ@4V456@A+16"
         instr11 = "\tlea\trcx, OFFSET FLAT:??_R0N@8+8"
         instr12 = "\tvfmadd213sd xmm0, xmm1, QWORD PTR __real@bfc5555555555555"
+        instr13 = "\tjmp\t$LN18@operator"
 
         parsed_1 = self.parser.parse_instruction(instr1)
         parsed_2 = self.parser.parse_instruction(instr2)
@@ -106,6 +107,7 @@ class TestParserX86Intel(unittest.TestCase):
         parsed_10 = self.parser.parse_instruction(instr10)
         parsed_11 = self.parser.parse_instruction(instr11)
         parsed_12 = self.parser.parse_instruction(instr12)
+        parsed_13 = self.parser.parse_instruction(instr13)
 
         self.assertEqual(parsed_1.mnemonic, "sub")
         self.assertEqual(parsed_1.operands[0],
@@ -191,6 +193,10 @@ class TestParserX86Intel(unittest.TestCase):
                          RegisterOperand(name="XMM1"))
         self.assertEqual(parsed_12.operands[2],
                          MemoryOperand(offset=IdentifierOperand(name="__real@bfc5555555555555")))
+
+        self.assertEqual(parsed_13.mnemonic, "jmp")
+        self.assertEqual(parsed_13.operands[0],
+                         IdentifierOperand(name="$LN18@operator"))
 
     def test_parse_line(self):
         line_comment = "; -- Begin  main"

--- a/tests/test_parser_x86intel.py
+++ b/tests/test_parser_x86intel.py
@@ -92,6 +92,7 @@ class TestParserX86Intel(unittest.TestCase):
         instr9 = "\tlea\tr8, QWORD PTR [r8*4]"
         instr10 = "\tmovsd\txmm1, QWORD PTR boost@@XZ@4V456@A+16"
         instr11 = "\tlea\trcx, OFFSET FLAT:??_R0N@8+8"
+        instr12 = "\tvfmadd213sd xmm0, xmm1, QWORD PTR __real@bfc5555555555555"
 
         parsed_1 = self.parser.parse_instruction(instr1)
         parsed_2 = self.parser.parse_instruction(instr2)
@@ -104,6 +105,7 @@ class TestParserX86Intel(unittest.TestCase):
         parsed_9 = self.parser.parse_instruction(instr9)
         parsed_10 = self.parser.parse_instruction(instr10)
         parsed_11 = self.parser.parse_instruction(instr11)
+        parsed_12 = self.parser.parse_instruction(instr12)
 
         self.assertEqual(parsed_1.mnemonic, "sub")
         self.assertEqual(parsed_1.operands[0],
@@ -181,6 +183,14 @@ class TestParserX86Intel(unittest.TestCase):
         self.assertEqual(parsed_11.operands[1],
                          MemoryOperand(base=IdentifierOperand(name="??_R0N@8"),
                                        offset=ImmediateOperand(value=8)))
+
+        self.assertEqual(parsed_12.mnemonic, "vfmadd213sd")
+        self.assertEqual(parsed_12.operands[0],
+                         RegisterOperand(name="XMM0"))
+        self.assertEqual(parsed_12.operands[1],
+                         RegisterOperand(name="XMM1"))
+        self.assertEqual(parsed_12.operands[2],
+                         MemoryOperand(base=IdentifierOperand(name="__real@bfc5555555555555")))
 
     def test_parse_line(self):
         line_comment = "; -- Begin  main"

--- a/tests/test_parser_x86intel.py
+++ b/tests/test_parser_x86intel.py
@@ -152,7 +152,7 @@ class TestParserX86Intel(unittest.TestCase):
         self.assertEqual(parsed_7.operands[0],
                          RegisterOperand(name="RCX"))
         self.assertEqual(parsed_7.operands[1],
-                         MemoryOperand(base=IdentifierOperand(name="__FAC6D534_triad@c")))
+                         MemoryOperand(offset=IdentifierOperand(name="__FAC6D534_triad@c")))
 
         self.assertEqual(parsed_8.mnemonic, "mov")
         self.assertEqual(parsed_8.operands[0],
@@ -174,15 +174,15 @@ class TestParserX86Intel(unittest.TestCase):
         self.assertEqual(parsed_10.operands[0],
                          RegisterOperand(name="XMM1"))
         self.assertEqual(parsed_10.operands[1],
-                         MemoryOperand(base=IdentifierOperand(name="boost@@XZ@4V456@A"),
-                                       offset=ImmediateOperand(value=16)))
+                         MemoryOperand(offset=IdentifierOperand(name="boost@@XZ@4V456@A",
+                                                                offset=ImmediateOperand(value=16))))
 
         self.assertEqual(parsed_11.mnemonic, "lea")
         self.assertEqual(parsed_11.operands[0],
                          RegisterOperand(name="RCX"))
         self.assertEqual(parsed_11.operands[1],
-                         MemoryOperand(base=IdentifierOperand(name="??_R0N@8"),
-                                       offset=ImmediateOperand(value=8)))
+                         MemoryOperand(offset=IdentifierOperand(name="??_R0N@8",
+                                                                offset=ImmediateOperand(value=8))))
 
         self.assertEqual(parsed_12.mnemonic, "vfmadd213sd")
         self.assertEqual(parsed_12.operands[0],
@@ -190,7 +190,7 @@ class TestParserX86Intel(unittest.TestCase):
         self.assertEqual(parsed_12.operands[1],
                          RegisterOperand(name="XMM1"))
         self.assertEqual(parsed_12.operands[2],
-                         MemoryOperand(base=IdentifierOperand(name="__real@bfc5555555555555")))
+                         MemoryOperand(offset=IdentifierOperand(name="__real@bfc5555555555555")))
 
     def test_parse_line(self):
         line_comment = "; -- Begin  main"


### PR DESCRIPTION
1. Fallback to and from VEX-encoding during normalization when possible.
2. Improved support of jump addresses to match the expectations of the hardware models.
3. Parsing of addresses that are identifiers (possibly with a displacement) as a memory reference with an offset instead of a base.
4. Fix an off-by-one error in loop-carried dependencies.
5. Hack to reorder the arguments of comparison instructions.