### PR TITLE
More improvements to OSACA

### DIFF
--- a/osaca/data/isa/x86.yml
+++ b/osaca/data/isa/x86.yml
@@ -4158,7 +4158,7 @@ instruction_forms:
           name: "xmm"
           source: true
           destination: true
-    - name: [shl, shr, shlq, shrq]
+    - name: [sal, sar, salq, sarq, shl, shr, shlq, shrq]
       operands:
         - class: "immediate"
           imd: "int"

--- a/osaca/data/isa/x86.yml
+++ b/osaca/data/isa/x86.yml
@@ -3841,7 +3841,7 @@ instruction_forms:
           source: true
           destination: false
       # TODO sets MXCSR
-    - name: [vfmadd132pd, vfmadd213pd, vfmadd231pd]
+    - name: [vfmadd132pd, vfmadd213pd, vfmadd231pd, vfnmadd132pd, vfnmadd213pd, vfnmadd231pd]
       operands:
         - class: "register"
           name: "*"
@@ -3869,7 +3869,7 @@ instruction_forms:
           name: "*"
           source: true
           destination: true
-    - name: [vfmadd132sd, vfmadd213sd, vfmadd231sd]
+    - name: [vfmadd132sd, vfmadd213sd, vfmadd231sd, vfnmadd132sd, vfnmadd213sd, vfnmadd231sd]
       operands:
         - class: "register"
           name: "xmm"
@@ -3897,7 +3897,7 @@ instruction_forms:
           name: "xmm"
           source: true
           destination: true
-    - name: [vfmaddsub132pd, vfmaddsub213pd, vfmaddsub231pd]
+    - name: [vfmaddsub132pd, vfmaddsub213pd, vfmaddsub231pd, vfnmaddsub132pd, vfnmaddsub213pd, vfnmaddsub231pd]
       operands:
         - class: "register"
           name: "*"

--- a/osaca/data/isa/x86.yml
+++ b/osaca/data/isa/x86.yml
@@ -2437,6 +2437,79 @@ instruction_forms:
           name: "ZF"
           source: true
           destination: true
+    - name: comisd
+      operands:
+        - class: "register"
+          name: "xmm"
+          source: true
+          destination: false
+        - class: "register"
+          name: "xmm"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: "flag"
+          name: "CF"
+          source: false
+          destination: true
+        - class: "flag"
+          name: "OF"
+          source: false
+          destination: true
+        - class: "flag"
+          name: "SF"
+          source: false
+          destination: true
+        - class: "flag"
+          name: "ZF"
+          source: false
+          destination: true
+        - class: "flag"
+          name: "AF"
+          source: false
+          destination: true
+        - class: "flag"
+          name: "PF"
+          source: false
+          destination: true
+    - name: comisd
+      operands:
+        - class: "register"
+          name: "xmm"
+          source: true
+          destination: false
+        - class: "memory"
+          base: "*"
+          offset: "*"
+          index: "*"
+          scale: "*"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: "flag"
+          name: "CF"
+          source: false
+          destination: true
+        - class: "flag"
+          name: "OF"
+          source: false
+          destination: true
+        - class: "flag"
+          name: "SF"
+          source: false
+          destination: true
+        - class: "flag"
+          name: "ZF"
+          source: false
+          destination: true
+        - class: "flag"
+          name: "AF"
+          source: false
+          destination: true
+        - class: "flag"
+          name: "PF"
+          source: false
+          destination: true
     - name: dec
       operands:
         - class: "register"
@@ -3429,7 +3502,7 @@ instruction_forms:
         - class: "register"
           name: "gpr"
           source: true
-          destination: true 
+          destination: true
     - name: sbb
       operands:
         - class: "register"

--- a/osaca/data/isa/x86.yml
+++ b/osaca/data/isa/x86.yml
@@ -2437,7 +2437,7 @@ instruction_forms:
           name: "ZF"
           source: true
           destination: true
-    - name: comisd
+    - name: ["comisd", "ucomisd"]
       operands:
         - class: "register"
           name: "xmm"
@@ -2472,7 +2472,7 @@ instruction_forms:
           name: "PF"
           source: false
           destination: true
-    - name: comisd
+    - name: ["comisd", "ucomisd"]
       operands:
         - class: "register"
           name: "xmm"

--- a/osaca/data/model_importer.py
+++ b/osaca/data/model_importer.py
@@ -111,7 +111,7 @@ def extract_model(tree, arch, skip_mem=True):
         print("Skipping...", file=sys.stderr)
         return None
     mm = MachineModel(isa=isa)
-    # For now, the model uses the AT&T syntax.
+    # The model uses the AT&T syntax.
     parser = get_parser(isa, "ATT")
 
     for instruction_tag in tree.findall(".//instruction"):

--- a/osaca/osaca.py
+++ b/osaca/osaca.py
@@ -116,7 +116,7 @@ def create_parser(parser=None):
         "--syntax",
         type=str,
         help="Define the assembly syntax (ATT, Intel) for x86. If no syntax is given, OSACA "
-        "assumes that the ATT syntax is used.",
+        "tries to determine automatically the syntax to use.",
     )
     parser.add_argument(
         "--fixed",
@@ -248,7 +248,7 @@ def check_arguments(args, parser):
         )
     if args.syntax and args.syntax.upper() not in SUPPORTED_SYNTAXES:
         parser.error(
-            "Assembly syntax not supported. Please see --help for all valid assembly syntaxs."
+            "Assembly syntax not supported. Please see --help for all valid assembly syntaxes."
         )
     if "import_data" in args and args.import_data not in supported_import_files:
         parser.error(

--- a/osaca/semantics/arch_semantics.py
+++ b/osaca/semantics/arch_semantics.py
@@ -421,7 +421,6 @@ class ArchSemantics(ISASemantics):
 
     def convert_op_to_reg(self, reg_type, regtype="0"):
         """Create register operand for a memory addressing operand"""
-        # TODO: Intel
         if self._parser.isa() == "x86":
             if reg_type == "gpr":
                 register = RegisterOperand(name="r" + str(int(regtype) + 9))

--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -555,7 +555,7 @@ class KernelDG(nx.DiGraph):
                         graph.nodes[n]["style"] = "filled"
                     else:
                         graph.nodes[n]["style"] += ",filled"
-                    graph.nodes[n]["fillcolor"] = 2 + col
+                    graph.nodes[n]["fillcolor"] = 2 + col % 11
 
         # color edges
         for e in graph.edges:

--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -523,8 +523,8 @@ class KernelDG(nx.DiGraph):
         for dep in lcd:
             lcd_line_numbers[dep] = [x.line_number for x, lat in lcd[dep]["dependencies"]]
         # add color scheme
-        graph.graph["node"] = {"colorscheme": "accent8"}
-        graph.graph["edge"] = {"colorscheme": "accent8"}
+        graph.graph["node"] = {"colorscheme": "set312"}
+        graph.graph["edge"] = {"colorscheme": "set312"}
 
         # create LCD edges
         for dep in lcd_line_numbers:

--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -412,7 +412,7 @@ class KernelDG(nx.DiGraph):
             addr_change = 0
             if isinstance(src.offset, ImmediateOperand) and src.offset.value is not None:
                 addr_change += src.offset.value
-            if mem.offset:
+            if isinstance(mem.offset, ImmediateOperand) and mem.offset.value is not None:
                 addr_change -= mem.offset.value
             if mem.base and src.base:
                 base_change = register_changes.get(

--- a/osaca/semantics/marker_utils.py
+++ b/osaca/semantics/marker_utils.py
@@ -34,47 +34,6 @@ def reduce_to_section(kernel, parser):
     return kernel[start:end]
 
 
-def get_marker(isa, syntax, comment=""):
-    """Return tuple of start and end marker lines."""
-    isa = isa.lower()
-    if isa == "x86":
-        if syntax == "ATT":
-            start_marker_raw = (
-                "movl      $111, %ebx # OSACA START MARKER\n"
-                ".byte     100        # OSACA START MARKER\n"
-                ".byte     103        # OSACA START MARKER\n"
-                ".byte     144        # OSACA START MARKER\n"
-            )
-            if comment:
-                start_marker_raw += "# {}\n".format(comment)
-            end_marker_raw = (
-                "movl      $222, %ebx # OSACA END MARKER\n"
-                ".byte     100        # OSACA END MARKER\n"
-                ".byte     103        # OSACA END MARKER\n"
-                ".byte     144        # OSACA END MARKER\n"
-            )
-        elif syntax == "INTEL":
-            raise NotImplementedError
-    elif isa == "aarch64":
-        start_marker_raw = (
-            "mov       x1, #111    // OSACA START MARKER\n"
-            ".byte     213,3,32,31 // OSACA START MARKER\n"
-        )
-        if comment:
-            start_marker_raw += "// {}\n".format(comment)
-        # After loop
-        end_marker_raw = (
-            "mov       x1, #222    // OSACA END MARKER\n"
-            ".byte     213,3,32,31 // OSACA END MARKER\n"
-        )
-
-    parser = get_parser(isa, syntax)
-    start_marker = parser.parse_file(start_marker_raw)
-    end_marker = parser.parse_file(end_marker_raw)
-
-    return start_marker, end_marker
-
-
 def find_marked_section(lines, parser, comments=None):
     """
     Return indexes of marked section
@@ -86,7 +45,6 @@ def find_marked_section(lines, parser, comments=None):
     :type comments: dict, optional
     :returns: `tuple of int` -- start and end line of marked section
     """
-    # TODO match to instructions returned by get_marker
     index_start = -1
     index_end = -1
     start_marker = parser.start_marker()
@@ -114,7 +72,7 @@ def find_marked_section(lines, parser, comments=None):
 
 
 # This function and the following ones traverse the syntactic tree produced by the parser and try to
-# match it to the marker.  This is necessary because the IACA marker are significantly different on
+# match it to the marker.  This is necessary because the IACA markers are significantly different on
 # MSVC x86 than on other ISA/compilers.  Therefore, simple string matching is not sufficient.  Also,
 # the syntax of numeric literals depends on the parser and should not be known to this class.
 # The matching only checks for a limited number of properties (and the marker doesn't specify the

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -817,6 +817,9 @@ class TestSemanticTools(unittest.TestCase):
         instr_form_r_ymm = self.parser_x86_intel.parse_line("vmovapd ymm0, ymm1")
         self.semantics_csx_intel.normalize_instruction_form(instr_form_r_ymm)
         self.semantics_csx_intel.assign_src_dst(instr_form_r_ymm)
+        instr_form_rw_sar = self.parser_x86_intel.parse_line("sar rcx, 43")
+        self.semantics_csx_intel.normalize_instruction_form(instr_form_rw_sar)
+        self.semantics_csx_intel.assign_src_dst(instr_form_rw_sar)
         self.assertTrue(dag.is_read(reg_rcx, instr_form_r_c))
         self.assertFalse(dag.is_read(reg_rcx, instr_form_non_r_c))
         self.assertFalse(dag.is_read(reg_rcx, instr_form_w_c))
@@ -828,6 +831,8 @@ class TestSemanticTools(unittest.TestCase):
         self.assertTrue(dag.is_written(reg_ymm1, instr_form_rw_ymm_1))
         self.assertTrue(dag.is_written(reg_ymm1, instr_form_rw_ymm_2))
         self.assertFalse(dag.is_written(reg_ymm1, instr_form_r_ymm))
+        self.assertTrue(dag.is_read(reg_rcx, instr_form_rw_sar))
+        self.assertTrue(dag.is_written(reg_rcx, instr_form_rw_sar))
 
     def test_is_read_is_written_AArch64(self):
         # independent form HW model


### PR DESCRIPTION
1. Add some more instructions like `comisd`, `sar`, `sal`, etc. to the ISA description.
2. Clean up some TODOs and remove dead code.