### PR TITLE
Various bugs found while running OSACA on Cbrt

### DIFF
--- a/osaca/data/isa/x86.yml
+++ b/osaca/data/isa/x86.yml
@@ -2817,6 +2817,25 @@ instruction_forms:
           name: "xmm"
           source: true
           destination: true
+    - name: mul
+      operands:
+        - class: "register"
+          name: "rcx"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: "register"
+          name: "rdx"
+          source: false
+          destination: true
+        - class: "register"
+          name: "rax"
+          source: true
+          destination: true
+        - class: "register"
+          name: "ral"
+          source: true
+          destination: false
     - name: mulsd
       operands:
         - class: "register"

--- a/osaca/data/isa/x86.yml
+++ b/osaca/data/isa/x86.yml
@@ -2820,7 +2820,7 @@ instruction_forms:
     - name: mul
       operands:
         - class: "register"
-          name: "rcx"
+          name: "gpr"
           source: true
           destination: false
       hidden_operands:
@@ -2832,10 +2832,6 @@ instruction_forms:
           name: "rax"
           source: true
           destination: true
-        - class: "register"
-          name: "ral"
-          source: true
-          destination: false
     - name: mulsd
       operands:
         - class: "register"

--- a/osaca/osaca.py
+++ b/osaca/osaca.py
@@ -357,6 +357,7 @@ def inspect(args, output_file=sys.stdout):
 
     # Parse file.
     while True:
+        arch, syntax = combinations_to_try.pop()
         parser = get_asm_parser(arch, syntax)
         try:
             parsed_code = parser.parse_file(code)
@@ -366,7 +367,6 @@ def inspect(args, output_file=sys.stdout):
             if not combinations_to_try:
                 raise e
         combinations_to_try -= {(arch, syntax)}
-        arch, syntax = combinations_to_try.pop();
 
     # Reduce to marked kernel or chosen section and add semantics
     if args.lines:

--- a/osaca/parser/parser_x86intel.py
+++ b/osaca/parser/parser_x86intel.py
@@ -23,12 +23,18 @@ IDENTIFIER_START_CHARACTERS = "".join(
     chr(cp)
     for cp in range(0x10FFFF)
     if unicodedata.category(chr(cp)).startswith("L") or unicodedata.category(chr(cp)) == "Nl"
-)
+) + "∂𝛛𝜕𝝏𝞉𝟃∇𝛁𝛻𝜵𝝯𝞩∞"
 
 IDENTIFIER_CONTINUE_CHARACTERS = IDENTIFIER_START_CHARACTERS + "".join(
     chr(cp)
     for cp in range(0x10FFFF)
     if unicodedata.category(chr(cp)) in ("Mn", "Mc", "Nd", "Pc")
+) + "⁽₍⁾₎⁺₊⁼₌⁻₋⁰₀¹₁²₂³₃⁴₄⁵₅⁶₆⁷₇⁸₈⁹₉"
+
+PRINTABLE_CHARACTERS = "".join(
+    chr(cp)
+    for cp in range(0x10FFFF)
+    if unicodedata.category(chr(cp)) not in ("Cc", "Co", "Cn", "Cs")
 )
 
 # References:
@@ -206,7 +212,7 @@ class ParserX86Intel(ParserX86):
 
         # Comment.
         self.comment = pp.Literal(";") + pp.Group(
-            pp.ZeroOrMore(pp.Word(pp.printables))
+            pp.ZeroOrMore(pp.Word(PRINTABLE_CHARACTERS))
         ).setResultsName(self.comment_id)
 
         # Types.
@@ -451,7 +457,7 @@ class ParserX86Intel(ParserX86):
         directive_parameter = (
             pp.quotedString
             ^ (
-                pp.Word(pp.printables, excludeChars=",;")
+                pp.Word(PRINTABLE_CHARACTERS, excludeChars=",;")
                 + pp.Optional(pp.Suppress(pp.Literal(",")))
             )
             ^ pp.Suppress(pp.Literal(","))

--- a/osaca/parser/parser_x86intel.py
+++ b/osaca/parser/parser_x86intel.py
@@ -15,6 +15,11 @@ from osaca.parser.memory import MemoryOperand
 from osaca.parser.register import RegisterOperand
 from osaca.semantics.hw_model import MachineModel
 
+## TODO(egg): Switch to allowing all non-ASCII printables, based on the assumption that no assembler
+# will ever use non-ASCII white space and syntax.
+# This approach is described at the end of https://www.unicode.org/reports/tr55/#Whitespace-Syntax.
+# It is appropriate for tools, such as this one, which process source code but do not fully validate
+# it (in this case, that’s the job of the assembler).
 # Unicode 3.0-style definition because we do not have the UCD in the Python standard library, see
 # the derivation in Table 2 of UAX #31, https://www.unicode.org/reports/tr31/#Table_Lexical_Classes_for_Identifiers.
 # See also Table 5-7 in https://www.unicode.org/versions/Unicode3.0.0/ch05.pdf#page=31, and

--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -596,6 +596,7 @@ class KernelDG(nx.DiGraph):
         graph.graph["node"] = {"colorscheme" : colorscheme}
         graph.graph["edge"] = {"colorscheme" : colorscheme}
         for n, color in node_colors.items():
+            color = min(color, max_color)
             if "style" not in graph.nodes[n]:
                 graph.nodes[n]["style"] = "filled"
             else:
@@ -607,6 +608,7 @@ class KernelDG(nx.DiGraph):
             ):
                 graph.nodes[n]["fontcolor"] = "white"
         for (u, v), color in edge_colors.items():
+            color = min(color, max_color)
             # The backward edge of the cycle is represented as the corresponding forward
             # edge with the attribute dir=back.
             edge = graph.edges[u, v] if (u, v) in graph.edges else graph.edges[v, u]


### PR DESCRIPTION
See https://github.com/mockingbirdnest/Principia/pull/4157.

* The (arch, syntax) trial logic was garbled.
* Comments can be non-ASCII. Don’t try to be unnecessarily smart about non-ASCII.
* The colour was not maxing out when generating the graph.
* [mul](https://www.felixcloutier.com/x86/mul) was missing.