### PR TITLE
Properly track the dependencies of the LOAD phase of instructions

### DIFF
--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -114,14 +114,12 @@ class KernelDG(nx.DiGraph):
                 if "p_indexed" in dep_flags and self.model is not None:
                     edge_weight = self.model.get("p_index_latency", 1)
                 if "for_load" in dep_flags and self.model is not None and dep.line_number in loads:
-                    #print("LOADDEP", instruction_form.line_number, loads[dep.line_number])
                     dg.add_edge(
                         instruction_form.line_number,
                         loads[dep.line_number],
                         latency=edge_weight,
                     )
                 else:
-                    #print("DEP", instruction_form.line_number, dep.line_number)
                     dg.add_edge(
                         instruction_form.line_number,
                         dep.line_number,
@@ -407,17 +405,13 @@ class KernelDG(nx.DiGraph):
                 is_read = self.parser.is_flag_dependend_of(register, src) or is_read
             if isinstance(src, MemoryOperand):
                 is_memory_read = False
-                #print("1", is_read)
                 if src.base is not None:
                     is_memory_read = self.parser.is_reg_dependend_of(register, src.base)
-                #print("2", is_read)
                 if src.index is not None and isinstance(src.index, RegisterOperand):
                     is_memory_read = (
                         self.parser.is_reg_dependend_of(register, src.index)
                         or is_memory_read
                     )
-                #print("3", is_read)
-                #print("FORLOAD", register, src)
                 for_load = is_memory_read
                 is_read = is_read or is_memory_read
         # Check also if read in destination memory address
@@ -568,7 +562,6 @@ class KernelDG(nx.DiGraph):
         lcd_line_numbers = {}
         for dep in lcd:
             lcd_line_numbers[dep] = [x.line_number for x, lat in lcd[dep]["dependencies"]]
-        print("LCDLN", lcd_line_numbers)
 
         # create LCD edges
         for dep in lcd_line_numbers:
@@ -581,7 +574,6 @@ class KernelDG(nx.DiGraph):
 
         # add label to edges
         for e in graph.edges:
-            print("EDGE", e)
             graph.edges[e]["label"] = graph.edges[e]["latency"]
 
         # add CP values to graph
@@ -594,8 +586,6 @@ class KernelDG(nx.DiGraph):
                 # graph.nodes[n]['color'] = 1
                 graph.nodes[n]["style"] = "bold"
                 graph.nodes[n]["penwidth"] = 4
-
-        print("CPLN", cp_line_numbers)
 
         # Make critical path edges bold.
         for u, v in zip(cp_line_numbers[:-1], cp_line_numbers[1:]):
@@ -630,7 +620,6 @@ class KernelDG(nx.DiGraph):
                         # Don’t introduce a color just for an edge.
                         if not color:
                             color = colors_used
-                        print("EC", u, v, color)
                         edge_colors[u, v] = color
         max_color = min(11, colors_used)
         colorscheme = f"spectral{max(3, max_color)}"

--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -58,7 +58,8 @@ class KernelDG(nx.DiGraph):
     @staticmethod
     def get_load_line_number(line_number):
         # The line number of the load must be less than the line number of the instruction.  The
-        # offset is irrelevant, but it must be a machine number to avoid silly rounding issues.
+        # offset is irrelevant, but it must be a machine number with trailing zeroes to avoid silly
+        # rounding issues.
         return line_number - 0.125
 
     @staticmethod

--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -57,8 +57,9 @@ class KernelDG(nx.DiGraph):
 
     @staticmethod
     def get_load_line_number(line_number):
-        # The offset is irrelevant, but it must be a machine number to avoid silly rounding issues.
-        return line_number + 0.125
+        # The line number of the load must be less than the line number of the instruction.  The
+        # offset is irrelevant, but it must be a machine number to avoid silly rounding issues.
+        return line_number - 0.125
 
     def create_DG(self, kernel, flag_dependencies=False):
         """
@@ -80,7 +81,6 @@ class KernelDG(nx.DiGraph):
             dg.add_node(instruction_form.line_number)
             dg.nodes[instruction_form.line_number]["instruction_form"] = instruction_form
             # add load as separate node if existent
-            load_line_number = None
             if (
                 INSTR_FLAGS.HAS_LD in instruction_form.flags
                 and INSTR_FLAGS.LD not in instruction_form.flags
@@ -100,7 +100,6 @@ class KernelDG(nx.DiGraph):
                     latency=instruction_form.latency - instruction_form.latency_wo_load,
                 )
         #TODO comments
-        print("LOADS", loads)
         for i, instruction_form in enumerate(kernel):
             for dep, dep_flags in self.find_depending(
                 instruction_form, kernel[i + 1 :], flag_dependencies
@@ -407,15 +406,20 @@ class KernelDG(nx.DiGraph):
             if isinstance(src, FlagOperand):
                 is_read = self.parser.is_flag_dependend_of(register, src) or is_read
             if isinstance(src, MemoryOperand):
+                is_memory_read = False
                 #print("1", is_read)
                 if src.base is not None:
-                    is_read = self.parser.is_reg_dependend_of(register, src.base) or is_read
+                    is_memory_read = self.parser.is_reg_dependend_of(register, src.base)
                 #print("2", is_read)
                 if src.index is not None and isinstance(src.index, RegisterOperand):
-                    is_read = self.parser.is_reg_dependend_of(register, src.index) or is_read
+                    is_memory_read = (
+                        self.parser.is_reg_dependend_of(register, src.index)
+                        or is_memory_read
+                    )
                 #print("3", is_read)
                 #print("FORLOAD", register, src)
-                for_load = True
+                for_load = is_memory_read
+                is_read = is_read or is_memory_read
         # Check also if read in destination memory address
         for dst in chain(
             instruction_form.semantic_operands["destination"],

--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -84,9 +84,8 @@ class KernelDG(nx.DiGraph):
         :type flag_dependencies: boolean, optional
         :returns: :class:`~nx.DiGraph` -- directed graph object
         """
-        # 1. go through kernel instruction forms and add them as node attribute
-        # 2. find edges (to dependend further instruction)
-        # 3. get LT value and set as edge weight
+        # Go through kernel instruction forms and add them as nodes of the graph.  Create a LOAD
+        # node for instructions that include a memory reference.
         dg = nx.DiGraph()
         loads = {}
         for i, instruction_form in enumerate(kernel):
@@ -112,11 +111,14 @@ class KernelDG(nx.DiGraph):
                     instruction_form.line_number,
                     latency=instruction_form.latency - instruction_form.latency_wo_load,
                 )
-        #TODO comments
+
+        # 1. find edges (to dependend further instruction)
+        # 2. get LT value and set as edge weight
         for i, instruction_form in enumerate(kernel):
             for dep, operand, dep_flags in self.find_depending(
                 instruction_form, kernel[i + 1 :], flag_dependencies
             ):
+                # print(instruction_form.line_number,"\t",dep.line_number,"\n")
                 edge_weight = (
                     instruction_form.latency
                     if "mem_dep" in dep_flags or instruction_form.latency_wo_load is None

--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -61,6 +61,18 @@ class KernelDG(nx.DiGraph):
         # offset is irrelevant, but it must be a machine number to avoid silly rounding issues.
         return line_number - 0.125
 
+    @staticmethod
+    def is_load_line_number(line_number):
+        return line_number != int(line_number)
+
+    @staticmethod
+    def get_real_line_number(line_number):
+        return (
+            int(line_number + 0.125)
+            if KernelDG.is_load_line_number(line_number)
+            else line_number
+        )
+
     def create_DG(self, kernel, flag_dependencies=False):
         """
         Create directed graph from given kernel
@@ -90,6 +102,7 @@ class KernelDG(nx.DiGraph):
                 loads[instruction_form.line_number] = load_line_number
                 dg.add_node(load_line_number)
                 dg.nodes[load_line_number]["instruction_form"] = InstructionForm(
+                    mnemonic="_LOAD_",
                     line=instruction_form.line,
                     line_number=load_line_number
                 )
@@ -645,21 +658,17 @@ class KernelDG(nx.DiGraph):
         # rename node from [idx] to [idx mnemonic] and add shape
         mapping = {}
         for n in graph.nodes:
-            if int(n) != n:
-                mapping[n] = "{}: LOAD".format(int(n))
+            node = graph.nodes[n]["instruction_form"]
+            if node.mnemonic is not None:
+                mapping[n] = "{}: {}".format(KernelDG.get_real_line_number(n), node.mnemonic)
+            else:
+                label = "label" if node.label is not None else None
+                label = "directive" if node.directive is not None else label
+                label = "comment" if node.comment is not None and label is None else label
+                mapping[n] = "{}: {}".format(n, label)
                 graph.nodes[n]["fontname"] = "italic"
                 graph.nodes[n]["fontsize"] = 11.0
-            else:
-                node = graph.nodes[n]["instruction_form"]
-                if node.mnemonic is not None:
-                    mapping[n] = "{}: {}".format(n, node.mnemonic)
-                else:
-                    label = "label" if node.label is not None else None
-                    label = "directive" if node.directive is not None else label
-                    label = "comment" if node.comment is not None and label is None else label
-                    mapping[n] = "{}: {}".format(n, label)
-                    graph.nodes[n]["fontname"] = "italic"
-                    graph.nodes[n]["fontsize"] = 11.0
+            if not KernelDG.is_load_line_number(n):
                 graph.nodes[n]["shape"] = "rectangle"
 
         nx.relabel.relabel_nodes(graph, mapping, copy=False)

--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -10,6 +10,7 @@ from multiprocessing import Manager, Process, cpu_count
 
 import networkx as nx
 from osaca.semantics import INSTR_FLAGS, ArchSemantics, MachineModel
+from osaca.parser.instruction_form import InstructionForm
 from osaca.parser.memory import MemoryOperand
 from osaca.parser.register import RegisterOperand
 from osaca.parser.immediate import ImmediateOperand
@@ -88,7 +89,10 @@ class KernelDG(nx.DiGraph):
                 load_line_number = KernelDG.get_load_line_number(instruction_form.line_number)
                 loads[instruction_form.line_number] = load_line_number
                 dg.add_node(load_line_number)
-                dg.nodes[load_line_number]["instruction_form"] = instruction_form
+                dg.nodes[load_line_number]["instruction_form"] = InstructionForm(
+                    line=instruction_form.line,
+                    line_number=load_line_number
+                )
                 # and set LD latency as edge weight
                 dg.add_edge(
                     load_line_number,
@@ -96,16 +100,11 @@ class KernelDG(nx.DiGraph):
                     latency=instruction_form.latency - instruction_form.latency_wo_load,
                 )
         #TODO comments
-        #print("LOADS", loads)
+        print("LOADS", loads)
         for i, instruction_form in enumerate(kernel):
             for dep, dep_flags in self.find_depending(
                 instruction_form, kernel[i + 1 :], flag_dependencies
             ):
-                #if instruction_form.mnemonic == 'shl':
-                 #   print("IF", instruction_form)
-                  #  print("DEP", dep)
-                   # print("DF", dep_flags)
-                # print(instruction_form.line_number,"\t",dep.line_number,"\n")
                 edge_weight = (
                     instruction_form.latency
                     if "mem_dep" in dep_flags or instruction_form.latency_wo_load is None
@@ -123,6 +122,7 @@ class KernelDG(nx.DiGraph):
                         latency=edge_weight,
                     )
                 else:
+                    #print("DEP", instruction_form.line_number, dep.line_number)
                     dg.add_edge(
                         instruction_form.line_number,
                         dep.line_number,
@@ -236,26 +236,17 @@ class KernelDG(nx.DiGraph):
         for lat_sum, involved_lines in loopcarried_deps:
             dict_key = "-".join([str(il[0]) for il in involved_lines])
             loopcarried_deps_dict[dict_key] = {
-                "root": self._get_node_by_lineno(involved_lines[0][0]),
+                "root": self._get_node_by_lineno(dg, involved_lines[0][0]),
                 "dependencies": [
-                    (self._get_node_by_lineno(ln), lat) for ln, lat in involved_lines
+                    (self._get_node_by_lineno(dg, ln), lat) for ln, lat in involved_lines
                 ],
                 "latency": lat_sum,
             }
         return loopcarried_deps_dict
 
-    def _get_node_by_lineno(self, lineno, kernel=None, all=False):
-        """Return instruction form with line number ``lineno`` from  kernel"""
-        #print(lineno)
-        if kernel is None:
-            kernel = self.kernel
-        result = [instr for instr in kernel
-                  if instr.line_number == lineno
-                  or KernelDG.get_load_line_number(instr.line_number) == lineno]
-        if not all:
-            return result[0]
-        else:
-            return result
+    def _get_node_by_lineno(self, dg, lineno):
+        """Return instruction form with line number ``lineno`` from  dg"""
+        return dg.nodes[lineno]["instruction_form"]
 
     def get_critical_path(self):
         """Find and return critical path after the creation of a directed graph."""
@@ -264,21 +255,21 @@ class KernelDG(nx.DiGraph):
             longest_path = nx.algorithms.dag.dag_longest_path(self.dg, weight="latency")
             # TODO verify that we can remove the next two lince due to earlier initialization
             for line_number in longest_path:
-                self._get_node_by_lineno(int(line_number)).latency_cp = 0
+                self._get_node_by_lineno(self.dg, line_number).latency_cp = 0
             # set cp latency to instruction
             path_latency = 0.0
             for s, d in nx.utils.pairwise(longest_path):
-                node = self._get_node_by_lineno(int(s))
+                node = self._get_node_by_lineno(self.dg, s)
                 node.latency_cp = self.dg.edges[(s, d)]["latency"]
                 path_latency += node.latency_cp
             # add latency for last instruction
-            node = self._get_node_by_lineno(int(longest_path[-1]))
+            node = self._get_node_by_lineno(self.dg, longest_path[-1])
             node.latency_cp = node.latency
             if max_latency_instr.latency > path_latency:
                 max_latency_instr.latency_cp = float(max_latency_instr.latency)
                 return [max_latency_instr]
             else:
-                return [x for x in self.kernel if x.line_number in longest_path]
+                return [self._get_node_by_lineno(self.dg, x) for x in longest_path]
         else:
             # split to DAG
             raise NotImplementedError("Kernel is cyclic.")
@@ -573,6 +564,7 @@ class KernelDG(nx.DiGraph):
         lcd_line_numbers = {}
         for dep in lcd:
             lcd_line_numbers[dep] = [x.line_number for x, lat in lcd[dep]["dependencies"]]
+        print("LCDLN", lcd_line_numbers)
 
         # create LCD edges
         for dep in lcd_line_numbers:
@@ -585,6 +577,7 @@ class KernelDG(nx.DiGraph):
 
         # add label to edges
         for e in graph.edges:
+            print("EDGE", e)
             graph.edges[e]["label"] = graph.edges[e]["latency"]
 
         # add CP values to graph
@@ -598,20 +591,12 @@ class KernelDG(nx.DiGraph):
                 graph.nodes[n]["style"] = "bold"
                 graph.nodes[n]["penwidth"] = 4
 
+        print("CPLN", cp_line_numbers)
+
         # Make critical path edges bold.
-        for e in graph.edges:
-            if (
-                graph.nodes[e[0]]["instruction_form"].line_number in cp_line_numbers
-                and graph.nodes[e[1]]["instruction_form"].line_number in cp_line_numbers
-                and e[0] < e[1]
-            ):
-                bold_edge = True
-                for i in range(e[0] + 1, e[1]):
-                    if i in cp_line_numbers:
-                        bold_edge = False
-                if bold_edge:
-                    graph.edges[e]["style"] = "bold"
-                    graph.edges[e]["penwidth"] = 3
+        for u, v in zip(cp_line_numbers[:-1], cp_line_numbers[1:]):
+            graph.edges[u, v]["style"] = "bold"
+            graph.edges[u, v]["penwidth"] = 3
 
         # Color the cycles created by loop-carried dependencies, longest first, never recoloring
         # any node or edge, so that the longest LCD and most long chains that are involved in the
@@ -641,6 +626,7 @@ class KernelDG(nx.DiGraph):
                         # Don’t introduce a color just for an edge.
                         if not color:
                             color = colors_used
+                        print("EC", u, v, color)
                         edge_colors[u, v] = color
         max_color = min(11, colors_used)
         colorscheme = f"spectral{max(3, max_color)}"

--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import copy
+from enum import Enum
 import os
 import signal
 import time
@@ -18,6 +19,11 @@ from osaca.parser.flag import FlagOperand
 class KernelDG(nx.DiGraph):
     # threshold for checking dependency graph sequential or in parallel
     INSTRUCTION_THRESHOLD = 50
+
+    class ReadKind(Enum):
+        NOT_A_READ = 0
+        READ_FOR_LOAD = 1
+        OTHER_READ = 2
 
     def __init__(
         self,
@@ -48,6 +54,11 @@ class KernelDG(nx.DiGraph):
             dst_list.extend(tmp_list)
         # print('Thread [{}-{}] done'.format(kernel[0]['line_number'], kernel[-1]['line_number']))
 
+    @staticmethod
+    def get_load_line_number(line_number):
+        # The offset is irrelevant, but it must be a machine number to avoid silly rounding issues.
+        return line_number + 0.125
+
     def create_DG(self, kernel, flag_dependencies=False):
         """
         Create directed graph from given kernel
@@ -63,26 +74,37 @@ class KernelDG(nx.DiGraph):
         # 2. find edges (to dependend further instruction)
         # 3. get LT value and set as edge weight
         dg = nx.DiGraph()
+        loads = {}
         for i, instruction_form in enumerate(kernel):
             dg.add_node(instruction_form.line_number)
             dg.nodes[instruction_form.line_number]["instruction_form"] = instruction_form
             # add load as separate node if existent
+            load_line_number = None
             if (
                 INSTR_FLAGS.HAS_LD in instruction_form.flags
                 and INSTR_FLAGS.LD not in instruction_form.flags
             ):
                 # add new node
-                dg.add_node(instruction_form.line_number + 0.1)
-                dg.nodes[instruction_form.line_number + 0.1]["instruction_form"] = instruction_form
+                load_line_number = KernelDG.get_load_line_number(instruction_form.line_number)
+                loads[instruction_form.line_number] = load_line_number
+                dg.add_node(load_line_number)
+                dg.nodes[load_line_number]["instruction_form"] = instruction_form
                 # and set LD latency as edge weight
                 dg.add_edge(
-                    instruction_form.line_number + 0.1,
+                    load_line_number,
                     instruction_form.line_number,
                     latency=instruction_form.latency - instruction_form.latency_wo_load,
                 )
+        #TODO comments
+        #print("LOADS", loads)
+        for i, instruction_form in enumerate(kernel):
             for dep, dep_flags in self.find_depending(
                 instruction_form, kernel[i + 1 :], flag_dependencies
             ):
+                #if instruction_form.mnemonic == 'shl':
+                 #   print("IF", instruction_form)
+                  #  print("DEP", dep)
+                   # print("DF", dep_flags)
                 # print(instruction_form.line_number,"\t",dep.line_number,"\n")
                 edge_weight = (
                     instruction_form.latency
@@ -93,11 +115,19 @@ class KernelDG(nx.DiGraph):
                     edge_weight += self.model.get("store_to_load_forward_latency", 0)
                 if "p_indexed" in dep_flags and self.model is not None:
                     edge_weight = self.model.get("p_index_latency", 1)
-                dg.add_edge(
-                    instruction_form.line_number,
-                    dep.line_number,
-                    latency=edge_weight,
-                )
+                if "for_load" in dep_flags and self.model is not None and dep.line_number in loads:
+                    #print("LOADDEP", instruction_form.line_number, loads[dep.line_number])
+                    dg.add_edge(
+                        instruction_form.line_number,
+                        loads[dep.line_number],
+                        latency=edge_weight,
+                    )
+                else:
+                    dg.add_edge(
+                        instruction_form.line_number,
+                        dep.line_number,
+                        latency=edge_weight,
+                    )
 
                 dg.nodes[dep.line_number]["instruction_form"] = dep
         return dg
@@ -216,9 +246,12 @@ class KernelDG(nx.DiGraph):
 
     def _get_node_by_lineno(self, lineno, kernel=None, all=False):
         """Return instruction form with line number ``lineno`` from  kernel"""
+        #print(lineno)
         if kernel is None:
             kernel = self.kernel
-        result = [instr for instr in kernel if instr.line_number == lineno]
+        result = [instr for instr in kernel
+                  if instr.line_number == lineno
+                  or KernelDG.get_load_line_number(instr.line_number) == lineno]
         if not all:
             return result[0]
         else:
@@ -286,15 +319,18 @@ class KernelDG(nx.DiGraph):
                 # print("  TO", instr_form.line, register_changes)
                 if isinstance(dst, RegisterOperand):
                     # read of register
-                    if self.is_read(dst, instr_form):
+                    read_kind = self._read_kind(dst, instr_form)
+                    if read_kind != KernelDG.ReadKind.NOT_A_READ:
+                        dep_flags = []
                         if (
                             dst.pre_indexed
                             or dst.post_indexed
                             or (isinstance(dst.post_indexed, dict))
                         ):
-                            yield instr_form, ["p_indexed"]
-                        else:
-                            yield instr_form, []
+                            dep_flags = ["p_indexed"]
+                        if read_kind == KernelDG.ReadKind.READ_FOR_LOAD:
+                            dep_flags += ["for_load"]
+                        yield instr_form, dep_flags
                     # write to register -> abort
                     if self.is_written(dst, instr_form):
                         break
@@ -365,11 +401,12 @@ class KernelDG(nx.DiGraph):
             return self.dg.successors(line_number)
         return iter([])
 
-    def is_read(self, register, instruction_form):
-        """Check if instruction form reads from given register"""
+    def _read_kind(self, register, instruction_form):
+        """Check if instruction form reads from given register.  Returns a ReadKind."""
         is_read = False
+        for_load = False
         if instruction_form.semantic_operands is None:
-            return is_read
+            return KernelDG.ReadKind.NOT_A_READ
         for src in chain(
             instruction_form.semantic_operands["source"],
             instruction_form.semantic_operands["src_dst"],
@@ -379,10 +416,15 @@ class KernelDG(nx.DiGraph):
             if isinstance(src, FlagOperand):
                 is_read = self.parser.is_flag_dependend_of(register, src) or is_read
             if isinstance(src, MemoryOperand):
+                #print("1", is_read)
                 if src.base is not None:
                     is_read = self.parser.is_reg_dependend_of(register, src.base) or is_read
+                #print("2", is_read)
                 if src.index is not None and isinstance(src.index, RegisterOperand):
                     is_read = self.parser.is_reg_dependend_of(register, src.index) or is_read
+                #print("3", is_read)
+                #print("FORLOAD", register, src)
+                for_load = True
         # Check also if read in destination memory address
         for dst in chain(
             instruction_form.semantic_operands["destination"],
@@ -393,7 +435,16 @@ class KernelDG(nx.DiGraph):
                     is_read = self.parser.is_reg_dependend_of(register, dst.base) or is_read
                 if dst.index is not None:
                     is_read = self.parser.is_reg_dependend_of(register, dst.index) or is_read
-        return is_read
+        if is_read:
+            if for_load:
+                return KernelDG.ReadKind.READ_FOR_LOAD
+            else:
+                return KernelDG.ReadKind.OTHER_READ
+        else:
+            return KernelDG.ReadKind.NOT_A_READ
+
+    def is_read(self, register, instruction_form):
+        return self._read_kind(register, instruction_form) != KernelDG.ReadKind.NOT_A_READ
 
     def is_memload(self, mem, instruction_form, register_changes={}):
         """Check if instruction form loads from given location, assuming register_changes"""

--- a/tests/test_files/kernel_x86_intel_memdep.asm
+++ b/tests/test_files/kernel_x86_intel_memdep.asm
@@ -1,4 +1,4 @@
-; Translated from kernal_x86_memdep.s
+; Translated from kernel_x86_memdep.s
 L4:
   vmovsd [rax+8], xmm0
   add rax, 8
@@ -14,3 +14,6 @@ L4:
   add rax, 8
   cmp rsi, rax
   jne L4
+; Added to test LOAD dependencies
+  shl rax, 5
+  subsd xmm10, QWORD PTR [rax+r8]

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -94,6 +94,9 @@ class TestSemanticTools(unittest.TestCase):
         cls.machine_model_csx = MachineModel(
             path_to_yaml=os.path.join(cls.MODULE_DATA_DIR, "csx.yml")
         )
+        cls.machine_model_skx = MachineModel(
+            path_to_yaml=os.path.join(cls.MODULE_DATA_DIR, "skx.yml")
+        )
         cls.machine_model_tx2 = MachineModel(
             path_to_yaml=os.path.join(cls.MODULE_DATA_DIR, "tx2.yml")
         )
@@ -110,6 +113,11 @@ class TestSemanticTools(unittest.TestCase):
         cls.semantics_csx_intel = ArchSemantics(
             cls.parser_x86_intel,
             cls.machine_model_csx,
+            path_to_yaml=os.path.join(cls.MODULE_DATA_DIR, "isa/x86.yml"),
+        )
+        cls.semantics_skx_intel = ArchSemantics(
+            cls.parser_x86_intel,
+            cls.machine_model_skx,
             path_to_yaml=os.path.join(cls.MODULE_DATA_DIR, "isa/x86.yml"),
         )
         cls.semantics_aarch64 = ISASemantics(cls.parser_AArch64)
@@ -141,10 +149,10 @@ class TestSemanticTools(unittest.TestCase):
         for i in range(len(cls.kernel_x86_intel)):
             cls.semantics_csx_intel.assign_src_dst(cls.kernel_x86_intel[i])
             cls.semantics_csx_intel.assign_tp_lt(cls.kernel_x86_intel[i])
-        cls.semantics_csx_intel.normalize_instruction_forms(cls.kernel_x86_intel_memdep)
+        cls.semantics_skx_intel.normalize_instruction_forms(cls.kernel_x86_intel_memdep)
         for i in range(len(cls.kernel_x86_intel_memdep)):
-            cls.semantics_csx_intel.assign_src_dst(cls.kernel_x86_intel_memdep[i])
-            cls.semantics_csx_intel.assign_tp_lt(cls.kernel_x86_intel_memdep[i])
+            cls.semantics_skx_intel.assign_src_dst(cls.kernel_x86_intel_memdep[i])
+            cls.semantics_skx_intel.assign_tp_lt(cls.kernel_x86_intel_memdep[i])
         cls.semantics_tx2.normalize_instruction_forms(cls.kernel_AArch64)
         for i in range(len(cls.kernel_AArch64)):
             cls.semantics_tx2.assign_src_dst(cls.kernel_AArch64[i])
@@ -510,12 +518,16 @@ class TestSemanticTools(unittest.TestCase):
         dg = KernelDG(
             self.kernel_x86_intel_memdep,
             self.parser_x86_intel,
-            self.machine_model_csx,
-            self.semantics_csx_intel,
+            self.machine_model_skx,
+            self.semantics_skx_intel,
         )
         self.assertTrue(nx.algorithms.dag.is_directed_acyclic_graph(dg.dg))
         self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=3)), {6, 8})
         self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=5)), {10, 12})
+        self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=5)), {10, 12})
+        self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=18)), {18.875})
+        self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=18.875)), {19})
+        self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=19)), set())
         with self.assertRaises(ValueError):
             dg.get_dependent_instruction_forms()
         # test dot creation

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -524,7 +524,6 @@ class TestSemanticTools(unittest.TestCase):
         self.assertTrue(nx.algorithms.dag.is_directed_acyclic_graph(dg.dg))
         self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=3)), {6, 8})
         self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=5)), {10, 12})
-        self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=5)), {10, 12})
         self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=18)), {18.875})
         self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=18.875)), {19})
         self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=19)), set())

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -474,7 +474,6 @@ class TestSemanticTools(unittest.TestCase):
             self.machine_model_csx,
             self.semantics_csx_intel
         )
-        print(dg.dg.adj)
         self.assertTrue(nx.algorithms.dag.is_directed_acyclic_graph(dg.dg))
         self.assertEqual(len(list(dg.get_dependent_instruction_forms(line_number=3))), 1)
         self.assertEqual(next(dg.get_dependent_instruction_forms(line_number=3)), 5)

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -466,7 +466,7 @@ class TestSemanticTools(unittest.TestCase):
         #   /  /
         #  4  /
         #    /
-        #  5.1
+        #  4.875
         #
         dg = KernelDG(
             self.kernel_x86_intel,
@@ -474,6 +474,7 @@ class TestSemanticTools(unittest.TestCase):
             self.machine_model_csx,
             self.semantics_csx_intel
         )
+        print(dg.dg.adj)
         self.assertTrue(nx.algorithms.dag.is_directed_acyclic_graph(dg.dg))
         self.assertEqual(len(list(dg.get_dependent_instruction_forms(line_number=3))), 1)
         self.assertEqual(next(dg.get_dependent_instruction_forms(line_number=3)), 5)
@@ -481,8 +482,8 @@ class TestSemanticTools(unittest.TestCase):
         self.assertEqual(next(dg.get_dependent_instruction_forms(line_number=4)), 5)
         self.assertEqual(len(list(dg.get_dependent_instruction_forms(line_number=5))), 1)
         self.assertEqual(next(dg.get_dependent_instruction_forms(line_number=5)), 6)
-        self.assertEqual(len(list(dg.get_dependent_instruction_forms(line_number=5.1))), 1)
-        self.assertEqual(next(dg.get_dependent_instruction_forms(line_number=5.1)), 5)
+        self.assertEqual(len(list(dg.get_dependent_instruction_forms(line_number=4.875))), 1)
+        self.assertEqual(next(dg.get_dependent_instruction_forms(line_number=4.875)), 5)
         self.assertEqual(list(dg.get_dependent_instruction_forms(line_number=6)), [])
         self.assertEqual(list(dg.get_dependent_instruction_forms(line_number=7)), [])
         self.assertEqual(list(dg.get_dependent_instruction_forms(line_number=8)), [])


### PR DESCRIPTION
Consider the following code snippet, on Skylake or Zen3:
```
	shl	rax, 5
	subsd	xmm10, QWORD PTR [rax+r8]
	movsd	xmm7, QWORD PTR [rax+r8+16]
```
Prior to this PR, OSACA would generate a LOAD node to represent of the memory reference of the `subsd` instruction, but would (incorrectly) assume that the LOAD was independent from every other instruction.  This resulted in a graph like this:

![bad_load](https://github.com/user-attachments/assets/c960477c-3711-4973-851e-d1f914731813)

Note how the LOAD looks like it can be executed on the first day of creation, when in reality it depends on the computation of `rax`.  Another way to look at it is that the subtraction above should not differ much from a sequence of `movsd` to load the memory location followed by `subsd` between registers.

With this PR the LOAD is correctly depending on the result of the `shl`, with significant changes to the critical path:

![good_load](https://github.com/user-attachments/assets/9987451b-a8f9-49c0-9277-e4b91b7837d7)

This change reveals another issue, this one with the architecture definition files.  For Cascade Lake, there is a definition for `subsd` reading from memory thus:
```
- name: SUBSD
  operands:
  - class: memory
    base: '*'
    offset: '*'
    index: '*'
    scale: '*'
  - class: register
    name: xmm
  latency: 4
  port_pressure: [[1, '015'], [1, '23'], [1, [2D, 3D]]]
  throughput: 0.5
  uops: 2                
```
While the pressure on ports 2 and 3 is correct (cf. Agner Fog), the latency is possibly incorrect in the case where the load cannot be executed early enough.  In the example above, the latency should really be 8 cycles.  For this reason, it seems preferable to never put entries for reading from memory in the tables, and always make the LOAD microoperation explicit.