### PR TITLE
Configure the dependencies of the jmeow instructions on flags

### DIFF
--- a/osaca/data/isa/x86.yml
+++ b/osaca/data/isa/x86.yml
@@ -530,6 +530,86 @@ instruction_forms:
           name: "rax"
           source: false
           destination: true
+    - name: [ja, jbe, jna, jnbe]
+      operands:
+        - class: identifier
+      hidden_operands:
+        - class: "flag"
+          name: "CF"
+          source: true
+          destination: false
+        - class: "flag"
+          name: "ZF"
+          source: true
+          destination: false
+    - name: [jae, jb, jc, jnae, jnb, jnc]
+      operands:
+        - class: identifier
+      hidden_operands:
+        - class: "flag"
+          name: "CF"
+          source: true
+          destination: false
+    - name: [je, jne, jnz, jz]
+      operands:
+        - class: identifier
+      hidden_operands:
+        - class: "flag"
+          name: "ZF"
+          source: true
+          destination: false
+    - name: [jg, jle, jng, jnle]
+      operands:
+        - class: identifier
+      hidden_operands:
+        - class: "flag"
+          name: "ZF"
+          source: true
+          destination: false
+        - class: "flag"
+          name: "SF"
+          source: true
+          destination: false
+        - class: "flag"
+          name: "OF"
+          source: true
+          destination: false
+    - name: [jge, jl, jnge, jnl]
+      operands:
+        - class: identifier
+      hidden_operands:
+        - class: "flag"
+          name: "SF"
+          source: true
+          destination: false
+        - class: "flag"
+          name: "OF"
+          source: true
+          destination: false
+    - name: [jno, jo]
+      operands:
+        - class: identifier
+      hidden_operands:
+        - class: "flag"
+          name: "OF"
+          source: true
+          destination: false
+    - name: [jnp, jp, jpe, jpo]
+      operands:
+        - class: identifier
+      hidden_operands:
+        - class: "flag"
+          name: "PF"
+          source: true
+          destination: false
+    - name: [jns, js]
+      operands:
+        - class: identifier
+      hidden_operands:
+        - class: "flag"
+          name: "SF"
+          source: true
+          destination: false
     - name: [seta, setbe, setna, setnbe]
       operands:
         - class: "register"


### PR DESCRIPTION
While they are never on the critical path, this attaches them to the dependency graph in the right place.